### PR TITLE
Add Netlify build pipeline, sitemap tooling, and React product card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
 __pycache__/
 *.pyc
 .env
-public/
+public/*
+!public/
+!public/robots.txt
+!public/sitemap.xml
 data/products.json
 .idea/
 .vscode/
 .DS_Store
+dist/
+node_modules/

--- a/functions/refresh_catalog.ts
+++ b/functions/refresh_catalog.ts
@@ -1,0 +1,91 @@
+import type { Handler } from "@netlify/functions";
+import { execFile } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, "..");
+const DATA_FILE = path.join(ROOT_DIR, "data", "products.json");
+const DEFAULT_PY_ARGS = ["-m", "giftgrab.cli", "update"];
+
+const parseProductsCount = async (): Promise<number> => {
+  try {
+    const raw = await fs.readFile(DATA_FILE, "utf8");
+    const payload = JSON.parse(raw);
+    if (Array.isArray(payload?.products)) {
+      return payload.products.length;
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.warn("Unable to parse product catalogue", error);
+    }
+  }
+  return 0;
+};
+
+const triggerBuild = async (): Promise<boolean> => {
+  const hook = process.env.NETLIFY_BUILD_HOOK ?? process.env.BUILD_HOOK_URL;
+  if (!hook) {
+    return false;
+  }
+  try {
+    const response = await fetch(hook, { method: "POST" });
+    if (!response.ok) {
+      console.warn("Build hook returned non-2xx status", response.status);
+    }
+    return response.ok;
+  } catch (error) {
+    console.warn("Failed to trigger build hook", error);
+    return false;
+  }
+};
+
+const runRefreshCommand = async (): Promise<void> => {
+  const pythonBinary = process.env.REFRESH_PYTHON_BINARY ?? "python";
+  const args = process.env.REFRESH_COMMAND
+    ? process.env.REFRESH_COMMAND.split(/\s+/).filter(Boolean)
+    : DEFAULT_PY_ARGS;
+  await execFileAsync(pythonBinary, args, {
+    cwd: ROOT_DIR,
+    env: {
+      ...process.env,
+      // Ensure the AFFIL_TAG flows through to the Python build for link hygiene.
+      AFFIL_TAG: process.env.AFFIL_TAG ?? "kayce25-20",
+    },
+  });
+};
+
+export const handler: Handler = async () => {
+  const startedAt = Date.now();
+  try {
+    await runRefreshCommand();
+  } catch (error) {
+    console.error("Catalogue refresh failed", error);
+    return {
+      statusCode: 500,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: "Failed to refresh catalogue",
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    };
+  }
+
+  const refreshedCount = await parseProductsCount();
+  const buildTriggered = await triggerBuild();
+
+  return {
+    statusCode: 200,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      refreshed: refreshedCount,
+      buildTriggered,
+      durationMs: Date.now() - startedAt,
+    }),
+  };
+};
+
+export default handler;

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,26 @@
 [build]
-  command = "python -m giftgrab.cli update"
-  publish = "public"
+  publish = "dist"
+  command = "npm run build"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "upgrade-insecure-requests"
+
+[[headers]]
+  for = "/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[plugins]]
+  package = "@netlify/plugin-lighthouse"
+
+[build.processing.html]
+  pretty_urls = true
 
 [build.environment]
-  PYTHON_VERSION = "3.11"
+  AFFIL_TAG = "kayce25-20"
+
+[[scheduled.functions]]
+  path = "functions/refresh_catalog.ts"
+  schedule = "@daily"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,181 @@
+{
+  "name": "grabgifts-site",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "grabgifts-site",
+      "version": "1.0.0",
+      "dependencies": {
+        "@netlify/functions": "^2.0.2",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.12.7",
+        "@types/react": "^18.2.74",
+        "@types/react-dom": "^18.2.24",
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/@netlify/functions": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-2.8.2.tgz",
+      "integrity": "sha512-DeoAQh8LuNPvBE4qsKlezjKj0PyXDryOFJfJKo3Z1qZLKzQ21sT314KQKPVjfvw6knqijj+IO+0kHXy/TJiqNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/serverless-functions-api": "1.26.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@netlify/node-cookies": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@netlify/node-cookies/-/node-cookies-0.1.0.tgz",
+      "integrity": "sha512-OAs1xG+FfLX0LoRASpqzVntVV/RpYkgpI0VrUnw2u0Q1qiZUzcPffxRK8HF3gc4GjuhG5ahOEMJ9bswBiZPq0g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@netlify/serverless-functions-api": {
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-1.26.1.tgz",
+      "integrity": "sha512-q3L9i3HoNfz0SGpTIS4zTcKBbRkxzCRpd169eyiTuk3IwcPC3/85mzLHranlKo2b+HYT0gu37YxGB45aD8A3Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/node-cookies": "^0.1.0",
+        "urlpattern-polyfill": "8.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
+      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "grabgifts-site",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "npm run guard:dedupe && npm run generate:sitemap && npm run compile && npm run copy:public",
+    "compile": "tsc --project tsconfig.json",
+    "generate:sitemap": "node ./scripts/build-sitemap.mjs",
+    "guard:dedupe": "node ./scripts/guard-dedupe.mjs",
+    "copy:public": "node ./scripts/copy-public.mjs"
+  },
+  "dependencies": {
+    "@netlify/functions": "^2.0.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.2.74",
+    "@types/react-dom": "^18.2.24",
+    "typescript": "^5.4.5"
+  }
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://www.grabgifts.net/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.grabgifts.net/</loc>
+    <lastmod>2025-09-19T15:25:53.994Z</lastmod>
+  </url>
+  <url>
+    <loc>https://www.grabgifts.net/guides</loc>
+    <lastmod>2025-09-19T15:25:53.994Z</lastmod>
+  </url>
+  <url>
+    <loc>https://www.grabgifts.net/for-him</loc>
+    <lastmod>2025-09-19T15:25:53.994Z</lastmod>
+  </url>
+  <url>
+    <loc>https://www.grabgifts.net/for-her</loc>
+    <lastmod>2025-09-19T15:25:53.994Z</lastmod>
+  </url>
+  <url>
+    <loc>https://www.grabgifts.net/techy</loc>
+    <lastmod>2025-09-19T15:25:53.994Z</lastmod>
+  </url>
+  <url>
+    <loc>https://www.grabgifts.net/gamers</loc>
+    <lastmod>2025-09-19T15:25:53.994Z</lastmod>
+  </url>
+  <url>
+    <loc>https://www.grabgifts.net/fandom</loc>
+    <lastmod>2025-09-19T15:25:53.994Z</lastmod>
+  </url>
+  <url>
+    <loc>https://www.grabgifts.net/homebody</loc>
+    <lastmod>2025-09-19T15:25:53.994Z</lastmod>
+  </url>
+</urlset>

--- a/scripts/build-sitemap.mjs
+++ b/scripts/build-sitemap.mjs
@@ -1,0 +1,106 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, "..");
+const DATA_FILE = path.join(ROOT_DIR, "data", "products.json");
+const PUBLIC_DIR = path.join(ROOT_DIR, "public");
+const SITEMAP_FILE = path.join(PUBLIC_DIR, "sitemap.xml");
+
+const STATIC_ROUTES = [
+  "/",
+  "/guides",
+  "/for-him",
+  "/for-her",
+  "/techy",
+  "/gamers",
+  "/fandom",
+  "/homebody",
+];
+
+const formatUrl = (base, route) => {
+  const normalized = route.startsWith("/") ? route : `/${route}`;
+  return new URL(normalized, base).toString();
+};
+
+const readJson = async (file) => {
+  try {
+    const content = await fs.readFile(file, "utf8");
+    return JSON.parse(content);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+};
+
+const slugify = (value) => {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-")
+    .trim();
+};
+
+const resolveProductSlug = (product) => {
+  if (typeof product.slug === "string" && product.slug.length > 0) {
+    return product.slug;
+  }
+  if (product.title && product.asin) {
+    return slugify(`${product.title}-${product.asin}`);
+  }
+  return null;
+};
+
+const buildEntries = async () => {
+  const baseUrl = process.env.SITE_BASE_URL ?? "https://www.grabgifts.net";
+  const now = new Date().toISOString();
+  const entries = STATIC_ROUTES.map((route) => ({
+    loc: formatUrl(baseUrl, route),
+    lastmod: now,
+  }));
+
+  const data = await readJson(DATA_FILE);
+  const products = Array.isArray(data?.products) ? data.products : [];
+  for (const product of products) {
+    if (!product) {
+      continue;
+    }
+    const slug = resolveProductSlug(product);
+    if (!slug) {
+      continue;
+    }
+    const lastmod = product.updated_at || product.updatedAt || now;
+    entries.push({
+      loc: formatUrl(baseUrl, `/p/${slug}`),
+      lastmod,
+    });
+  }
+  return entries;
+};
+
+const writeSitemap = async (entries) => {
+  const urlset = entries
+    .map((entry) => {
+      const lastmod = entry.lastmod ? `\n    <lastmod>${entry.lastmod}</lastmod>` : "";
+      return `  <url>\n    <loc>${entry.loc}</loc>${lastmod}\n  </url>`;
+    })
+    .join("\n");
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urlset}\n</urlset>\n`;
+  await fs.mkdir(PUBLIC_DIR, { recursive: true });
+  await fs.writeFile(SITEMAP_FILE, xml, "utf8");
+};
+
+const main = async () => {
+  const entries = await buildEntries();
+  await writeSitemap(entries);
+  console.log(`Wrote ${entries.length} entries to ${SITEMAP_FILE}`);
+};
+
+main().catch((error) => {
+  console.error("Failed to build sitemap", error);
+  process.exitCode = 1;
+});

--- a/scripts/copy-public.mjs
+++ b/scripts/copy-public.mjs
@@ -1,0 +1,50 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, "..");
+const DIST_DIR = path.join(ROOT_DIR, "dist");
+const PUBLIC_DIR = path.join(ROOT_DIR, "public");
+
+const copyRecursive = async (source, destination) => {
+  const stat = await fs.stat(source).catch((error) => {
+    if (error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  });
+  if (!stat) {
+    return;
+  }
+  if (!stat.isDirectory()) {
+    await fs.mkdir(path.dirname(destination), { recursive: true });
+    await fs.copyFile(source, destination);
+    return;
+  }
+  await fs.mkdir(destination, { recursive: true });
+  const entries = await fs.readdir(source, { withFileTypes: true });
+  await Promise.all(
+    entries.map(async (entry) => {
+      const srcPath = path.join(source, entry.name);
+      const destPath = path.join(destination, entry.name);
+      if (entry.isDirectory()) {
+        await copyRecursive(srcPath, destPath);
+      } else if (entry.isFile()) {
+        await fs.copyFile(srcPath, destPath);
+      }
+    })
+  );
+};
+
+const main = async () => {
+  await fs.rm(DIST_DIR, { recursive: true, force: true });
+  await fs.mkdir(DIST_DIR, { recursive: true });
+  await copyRecursive(PUBLIC_DIR, DIST_DIR);
+  console.log(`Copied public assets into ${DIST_DIR}`);
+};
+
+main().catch((error) => {
+  console.error("Failed to copy public assets", error);
+  process.exitCode = 1;
+});

--- a/scripts/guard-dedupe.mjs
+++ b/scripts/guard-dedupe.mjs
@@ -1,0 +1,99 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, "..");
+const DATA_FILE = path.join(ROOT_DIR, "data", "products.json");
+const COOLDOWN_DAYS = Number.parseInt(process.env.DEDUPE_COOLDOWN_DAYS ?? "30", 10);
+
+const readProducts = async () => {
+  try {
+    const raw = await fs.readFile(DATA_FILE, "utf8");
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed?.products)) {
+      return [];
+    }
+    return parsed.products;
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+};
+
+const parseTimestamp = (value) => {
+  if (!value || typeof value !== "string") {
+    return null;
+  }
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return null;
+  }
+  return new Date(timestamp);
+};
+
+const differenceInDays = (a, b) => {
+  const ms = Math.abs(a.getTime() - b.getTime());
+  return ms / (1000 * 60 * 60 * 24);
+};
+
+const dedupeKey = (product) => {
+  const asin = product?.asin;
+  const category = product?.primary_category || product?.category || product?.category_slug;
+  if (!asin || !category) {
+    return null;
+  }
+  return `${asin}:${category}`;
+};
+
+const main = async () => {
+  const products = await readProducts();
+  if (products.length === 0) {
+    console.log("No products found; skipping dedupe guard.");
+    return;
+  }
+
+  const map = new Map();
+  const duplicates = [];
+
+  for (const product of products) {
+    const key = dedupeKey(product);
+    if (!key) {
+      continue;
+    }
+    const updatedAt =
+      parseTimestamp(product.updated_at) ||
+      parseTimestamp(product.updatedAt) ||
+      new Date();
+    const entry = map.get(key);
+    if (entry) {
+      if (differenceInDays(updatedAt, entry.updatedAt) < COOLDOWN_DAYS) {
+        duplicates.push({ key, previous: entry.updatedAt.toISOString(), current: updatedAt.toISOString() });
+      } else if (updatedAt > entry.updatedAt) {
+        map.set(key, { updatedAt });
+      }
+    } else {
+      map.set(key, { updatedAt });
+    }
+  }
+
+  if (duplicates.length > 0) {
+    console.error("Duplicate products detected within cooldown window:");
+    for (const dup of duplicates) {
+      console.error(`  ${dup.key} (existing: ${dup.previous}, candidate: ${dup.current})`);
+    }
+    process.exitCode = 1;
+    throw new Error("Cooldown guard failed");
+  }
+
+  console.log(`Dedupe guard passed (${products.length} products checked).`);
+};
+
+main().catch((error) => {
+  if (process.exitCode !== 1) {
+    console.error("Failed to evaluate dedupe guard", error);
+    process.exitCode = 1;
+  }
+});

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,0 +1,150 @@
+import React, { useMemo } from "react";
+import { aff } from "../lib/affiliate";
+
+export interface ProductCardData {
+  slug: string;
+  title: string;
+  amazonUrl: string;
+  price?: string | null;
+  image?: string | null;
+  description?: string | null;
+  brand?: string | null;
+  rating?: number | null;
+  reviews?: number | null;
+  updatedAt: string;
+  availability?: string | null;
+}
+
+export interface ProductCardProps {
+  product: ProductCardData;
+  canonicalBaseUrl?: string;
+}
+
+const DEFAULT_BASE_URL = "https://www.grabgifts.net";
+const ISO_DATE_LENGTH = 10;
+
+const sanitizeBaseUrl = (value: string): string => {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+};
+
+const parsePrice = (price: string | null | undefined): number | undefined => {
+  if (!price) {
+    return undefined;
+  }
+  const match = price.match(/[0-9]+(?:\.[0-9]{1,2})?/);
+  if (!match) {
+    return undefined;
+  }
+  return Number.parseFloat(match[0]);
+};
+
+const detectCurrency = (price: string | null | undefined): string => {
+  if (!price) {
+    return "USD";
+  }
+  const symbol = price.trim().charAt(0);
+  switch (symbol) {
+    case "€":
+      return "EUR";
+    case "£":
+      return "GBP";
+    case "¥":
+      return "JPY";
+    case "C":
+      if (price.trim().startsWith("CA$")) {
+        return "CAD";
+      }
+      break;
+    default:
+      break;
+  }
+  return "USD";
+};
+
+const formatUpdatedAt = (updatedAt: string): string => {
+  if (!updatedAt) {
+    return "Unknown";
+  }
+  return updatedAt.slice(0, ISO_DATE_LENGTH);
+};
+
+const normalizeAvailability = (availability?: string | null): string => {
+  if (!availability) {
+    return "https://schema.org/InStock";
+  }
+  if (availability.startsWith("http")) {
+    return availability;
+  }
+  return `https://schema.org/${availability}`;
+};
+
+export const ProductCard: React.FC<ProductCardProps> = ({
+  product,
+  canonicalBaseUrl = DEFAULT_BASE_URL,
+}) => {
+  const canonicalUrl = `${sanitizeBaseUrl(canonicalBaseUrl)}/p/${product.slug}`;
+
+  const schemaPayload = useMemo(() => {
+    const offerPrice = parsePrice(product.price ?? undefined);
+    const payload = {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      name: product.title,
+      image: product.image ?? undefined,
+      description: product.description ?? undefined,
+      brand: product.brand ?? undefined,
+      aggregateRating:
+        product.rating != null
+          ? {
+              "@type": "AggregateRating",
+              ratingValue: product.rating,
+              reviewCount: product.reviews ?? undefined,
+            }
+          : undefined,
+      offers:
+        offerPrice != null
+          ? {
+              "@type": "Offer",
+              priceCurrency: detectCurrency(product.price ?? undefined),
+              price: offerPrice,
+              availability: normalizeAvailability(product.availability),
+              url: aff(product.amazonUrl),
+            }
+          : undefined,
+    } as const;
+    return JSON.stringify(payload, (_, value) => (value === undefined ? undefined : value));
+  }, [product.amazonUrl, product.availability, product.brand, product.description, product.image, product.price, product.rating, product.reviews, product.title]);
+
+  return (
+    <>
+      <link rel="canonical" href={canonicalUrl} />
+      <article className="product-card">
+        {product.image ? (
+          <img
+            src={product.image}
+            alt={product.title}
+            loading="lazy"
+            width={640}
+            height={640}
+          />
+        ) : null}
+        <h3 className="product-card__title">{product.title}</h3>
+        {product.description ? (
+          <p className="product-card__description">{product.description}</p>
+        ) : null}
+        <a
+          className="product-card__cta"
+          href={aff(product.amazonUrl)}
+          target="_blank"
+          rel="sponsored nofollow noopener"
+        >
+          View on Amazon
+        </a>
+        <p className="text-xs text-slate-500">Updated {formatUpdatedAt(product.updatedAt)}</p>
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: schemaPayload }} />
+      </article>
+    </>
+  );
+};
+
+export default ProductCard;

--- a/src/lib/affiliate.ts
+++ b/src/lib/affiliate.ts
@@ -1,0 +1,20 @@
+const DEFAULT_TAG = "kayce25-20";
+
+const sanitizeUrl = (url: string): URL => {
+  try {
+    return new URL(url);
+  } catch (error) {
+    throw new Error(`Invalid URL passed to aff(): ${url}`);
+  }
+};
+
+export const aff = (url: string): string => {
+  const result = sanitizeUrl(url);
+  const tag = process.env.AFFIL_TAG ?? DEFAULT_TAG;
+  if (tag && !result.searchParams.has("tag")) {
+    result.searchParams.set("tag", tag);
+  }
+  return result.toString();
+};
+
+export default aff;

--- a/src/lib/dedupe.ts
+++ b/src/lib/dedupe.ts
@@ -1,0 +1,10 @@
+export interface DedupeSource {
+  asin: string;
+  category: string;
+}
+
+export const dedupeKey = (payload: DedupeSource): string => {
+  return `${payload.asin}:${payload.category}`;
+};
+
+export default dedupeKey;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ES2020",
+    "moduleResolution": "Node", 
+    "lib": ["ES2021", "DOM"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "functions/**/*"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- switch Netlify to build the `dist` directory with the new Node/TypeScript toolchain and schedule the catalog refresh function
- add npm scripts plus sitemap and dedupe guards to emit `robots.txt`/`sitemap.xml` during builds
- implement affiliate utilities and a React product card that emit canonical links, JSON-LD, and compliant outbound CTAs

## Testing
- npm run build
- python -m unittest

------
https://chatgpt.com/codex/tasks/task_e_68cd700e28088333af74a59380f92166