### PR TITLE
Polish UI theme and clean guide titles

### DIFF
--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -7,9 +7,9 @@
   --card: rgba(20, 10, 34, 0.85);
   --border: rgba(125, 82, 178, 0.45);
   --shadow: 0 22px 50px rgba(6, 0, 30, 0.45);
-  --accent: #ff4fb8;
-  --accent-strong: #b94dff;
-  --accent-soft: rgba(255, 79, 184, 0.14);
+  --accent: #ff3d9e;
+  --accent-strong: #ff62c2;
+  --accent-soft: rgba(255, 61, 158, 0.12);
 }
 
 * {
@@ -89,8 +89,9 @@ main.wrap {
 }
 
 .logo {
-  width: 36px;
-  height: 36px;
+  width: 34px;
+  height: 34px;
+  filter: drop-shadow(0 6px 20px rgba(255, 61, 158, 0.35));
 }
 
 .logo.sm {
@@ -100,7 +101,7 @@ main.wrap {
 
 .brand-text {
   font-size: 1.1rem;
-  font-weight: 700;
+  font-weight: 800;
   letter-spacing: 0;
   text-transform: lowercase;
   background: linear-gradient(120deg, var(--accent) 0%, var(--accent-strong) 100%);
@@ -119,15 +120,23 @@ main.wrap {
 .footer-nav a {
   padding: 0.4rem 0.9rem;
   border-radius: 999px;
-  font-weight: 500;
   letter-spacing: 0;
   transition: background 0.2s ease, color 0.2s ease;
 }
 
+.site-nav a {
+  font-weight: 600;
+  opacity: 0.95;
+}
+
+.footer-nav a {
+  font-weight: 500;
+}
+
 .site-nav a:hover,
-.footer-nav a:hover {
-  background: var(--accent-soft);
-  color: var(--accent);
+.site-footer a:hover {
+  background: rgba(255, 61, 158, 0.12);
+  color: #ff3d9e;
 }
 
 .hero {
@@ -139,18 +148,6 @@ main.wrap {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-}
-
-.hero-badge {
-  align-self: flex-start;
-  padding: 0.35rem 0.9rem;
-  border-radius: 999px;
-  background: var(--accent-soft);
-  color: var(--accent);
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 
 .hero h1 {
@@ -176,7 +173,8 @@ main.wrap {
 }
 
 .button,
-.button:visited {
+.button:visited,
+a.button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -186,17 +184,17 @@ main.wrap {
   font-weight: 600;
   letter-spacing: 0;
   border: 0;
-  color: var(--fg);
-  background: linear-gradient(120deg, var(--accent) 0%, var(--accent-strong) 100%);
-  box-shadow: 0 12px 30px rgba(17, 0, 40, 0.45);
+  color: #120914;
+  background: #ff3d9e;
+  box-shadow: 0 12px 30px rgba(255, 61, 158, 0.35);
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
 }
 
 .button:hover {
   transform: translateY(-2px);
-  box-shadow: 0 18px 38px rgba(17, 0, 40, 0.55);
-  color: var(--fg);
+  box-shadow: 0 18px 38px rgba(255, 61, 158, 0.45);
+  color: #120914;
 }
 
 .button-secondary {
@@ -237,10 +235,10 @@ p {
 
 .card {
   background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 24px;
-  padding: 1.5rem;
-  box-shadow: var(--shadow);
+  border: 1px solid #2a2340;
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -260,6 +258,12 @@ p {
 .card h3 {
   font-size: 1.15rem;
   margin: 0;
+}
+
+.card h2 a,
+.card h3 a {
+  text-decoration: none;
+  border-bottom: 0;
 }
 
 .card p {

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,4 +1,4 @@
-from giftgrab.generator import SiteGenerator
+from giftgrab.generator import SiteGenerator, polish_guide_title
 from giftgrab.models import Product
 from giftgrab.repository import ProductRepository
 from giftgrab.roundups import generate_guides
@@ -63,3 +63,8 @@ def test_generator_outputs_required_files(tmp_path, monkeypatch):
     product_html = (output_dir / "products" / amazon_product.slug / "index.html").read_text(encoding="utf-8")
     assert 'rel="sponsored nofollow noopener"' in product_html
     assert "tag=testtag-20" in product_html
+
+
+def test_polish_guide_title_removes_for_a_and_right_now():
+    cleaned = polish_guide_title("Best For A Techy Gifts Right Now")
+    assert cleaned == "Best Tech Gifts"


### PR DESCRIPTION
## Summary
- update the generator to enforce the new hero description and reuse polished guide titles across rendered pages and feeds
- refresh the shared theme to match the accent, logo, navigation, button, and card requirements for the locked gradient look
- add title-polishing helpers to the Node build script and cover the formatter with a unit test

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdbd15925c8333b5a045efcf443587