### PR TITLE
Limit fixed background to fine pointers

### DIFF
--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -31,10 +31,15 @@ body {
     radial-gradient(120% 95% at 10% 0%, rgba(42, 12, 106, 0.85) 0%, rgba(10, 8, 16, 0) 65%),
     radial-gradient(100% 85% at 90% 5%, rgba(155, 15, 98, 0.85) 0%, rgba(10, 8, 16, 0) 70%),
     linear-gradient(180deg, var(--bg-start) 0%, var(--bg-mid) 45%, var(--bg-end) 100%);
-  background-attachment: fixed;
   min-height: 100%;
   -webkit-font-smoothing: antialiased;
   color-scheme: dark;
+}
+
+@media (pointer: fine) and (hover: hover) {
+  body {
+    background-attachment: fixed;
+  }
 }
 
 a {


### PR DESCRIPTION
## Summary
- allow the background gradient to scroll normally on touch devices to avoid black flashes
- keep the fixed background behavior for desktop-class pointers via a pointer/hover media query

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cdc07baa388333bfca2f37bc26f444