### PR TITLE
Add responsive navigation and infinite feed

### DIFF
--- a/public/assets/feed.js
+++ b/public/assets/feed.js
@@ -1,0 +1,279 @@
+const feedRoot = document.querySelector("[data-feed]");
+
+if (!feedRoot) {
+  return;
+}
+
+const listEl = feedRoot.querySelector("[data-feed-list]");
+if (!listEl) {
+  console.warn("[feed] Missing feed list container");
+  return;
+}
+
+const statusEl = feedRoot.querySelector("[data-feed-status]");
+const loadMoreButton = feedRoot.querySelector("[data-feed-more]");
+const sentinel = feedRoot.querySelector("[data-feed-sentinel]");
+const manifestUrl = feedRoot.dataset.feedManifest;
+
+const seenIds = new Set();
+listEl.querySelectorAll("[data-feed-id]").forEach((node) => {
+  const id = node.getAttribute("data-feed-id");
+  if (id) seenIds.add(id);
+});
+
+const toNumber = (value) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+};
+
+const state = {
+  currentPage: toNumber(feedRoot.dataset.feedPage),
+  totalPages: toNumber(feedRoot.dataset.feedTotal),
+  isLoading: false,
+  done: feedRoot.hasAttribute("data-feed-complete"),
+  manifest: null,
+};
+
+let observer = null;
+
+feedRoot.dataset.feedPage = String(state.currentPage);
+if (state.totalPages) {
+  feedRoot.dataset.feedTotal = String(state.totalPages);
+} else {
+  delete feedRoot.dataset.feedTotal;
+}
+
+if (state.done) {
+  if (statusEl) {
+    statusEl.hidden = false;
+    if (!statusEl.textContent) {
+      statusEl.textContent = "You're all caught up.";
+    }
+  }
+  if (loadMoreButton) {
+    loadMoreButton.disabled = true;
+    loadMoreButton.setAttribute("aria-disabled", "true");
+  }
+} else if (statusEl) {
+  statusEl.hidden = true;
+}
+
+function setStatus(message, { hidden = false } = {}) {
+  if (!statusEl) return;
+  if (typeof message === "string" && message) {
+    statusEl.textContent = message;
+  }
+  statusEl.hidden = hidden;
+}
+
+function setLoading(loading) {
+  state.isLoading = loading;
+  feedRoot.classList.toggle("is-loading", loading);
+  if (loadMoreButton) {
+    loadMoreButton.disabled = loading;
+    loadMoreButton.setAttribute("aria-busy", loading ? "true" : "false");
+  }
+}
+
+function markComplete() {
+  state.done = true;
+  feedRoot.setAttribute("data-feed-complete", "");
+  delete feedRoot.dataset.feedNext;
+  setStatus("You're all caught up.", { hidden: false });
+  if (loadMoreButton) {
+    loadMoreButton.disabled = true;
+    loadMoreButton.setAttribute("aria-disabled", "true");
+  }
+  if (observer) {
+    observer.disconnect();
+  }
+}
+
+async function ensureManifest() {
+  if (!manifestUrl || state.manifest) return;
+  try {
+    const response = await fetch(manifestUrl, { cache: "no-store" });
+    if (!response.ok) throw new Error(`Failed to load feed manifest: ${response.status}`);
+    const payload = await response.json();
+    if (payload && typeof payload === "object") {
+      state.manifest = payload;
+      if (typeof payload.totalPages === "number") {
+        state.totalPages = payload.totalPages;
+        feedRoot.dataset.feedTotal = String(state.totalPages);
+      }
+    }
+  } catch (error) {
+    console.error("[feed]", error);
+  }
+}
+
+function getPageUrl(page) {
+  if (!page || (state.totalPages && page > state.totalPages)) return null;
+  if (state.manifest && Array.isArray(state.manifest.pages)) {
+    const entry = state.manifest.pages.find((item) => item && item.page === page);
+    if (entry && entry.href) return entry.href;
+  }
+  return `/assets/feed/page-${page}.json`;
+}
+
+function createFeedCard(item) {
+  if (!item || !item.title || !item.url || !item.image) return null;
+  const article = document.createElement("article");
+  article.className = "feed-card";
+  if (item.id) article.dataset.feedId = item.id;
+
+  const link = document.createElement("a");
+  link.className = "feed-card-link";
+  link.href = item.url;
+  link.target = "_blank";
+  link.rel = "sponsored nofollow noopener";
+
+  const media = document.createElement("div");
+  media.className = "feed-card-media";
+  const img = document.createElement("img");
+  img.src = item.image;
+  img.alt = item.title;
+  img.loading = "lazy";
+  media.appendChild(img);
+
+  const body = document.createElement("div");
+  body.className = "feed-card-body";
+
+  const metaParts = [];
+  if (item.category) metaParts.push(item.category);
+  if (item.brand) metaParts.push(item.brand);
+  if (metaParts.length) {
+    const meta = document.createElement("p");
+    meta.className = "feed-card-meta";
+    meta.textContent = metaParts.join(" • ");
+    body.appendChild(meta);
+  }
+
+  const title = document.createElement("h3");
+  title.className = "feed-card-title";
+  title.textContent = item.title;
+  body.appendChild(title);
+
+  if (item.price) {
+    const price = document.createElement("p");
+    price.className = "feed-card-price";
+    price.textContent = item.price;
+    body.appendChild(price);
+  }
+
+  link.appendChild(media);
+  link.appendChild(body);
+  article.appendChild(link);
+  return article;
+}
+
+function appendItems(items) {
+  if (!Array.isArray(items)) return 0;
+  const fragment = document.createDocumentFragment();
+  let appended = 0;
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue;
+    const id = item.id;
+    if (id && seenIds.has(id)) continue;
+    const card = createFeedCard(item);
+    if (!card) continue;
+    if (id) seenIds.add(id);
+    fragment.appendChild(card);
+    appended += 1;
+  }
+  if (fragment.childNodes.length) {
+    listEl.querySelectorAll(".feed-empty").forEach((node) => node.remove());
+    listEl.appendChild(fragment);
+  }
+  return appended;
+}
+
+async function loadPage(page) {
+  await ensureManifest();
+  const url = getPageUrl(page);
+  if (!url) {
+    markComplete();
+    return;
+  }
+  setLoading(true);
+  setStatus("Loading new picks…", { hidden: false });
+  try {
+    const response = await fetch(url, { cache: "no-store" });
+    if (!response.ok) throw new Error(`Failed to load feed page ${page}: ${response.status}`);
+    const payload = await response.json();
+    const items = Array.isArray(payload?.items) ? payload.items : [];
+    const appended = appendItems(items);
+
+    const resolvedPage = Number(payload?.page);
+    if (Number.isFinite(resolvedPage) && resolvedPage > 0) {
+      state.currentPage = resolvedPage;
+    } else {
+      state.currentPage = page;
+    }
+
+    if (typeof payload?.totalPages === "number") {
+      state.totalPages = payload.totalPages;
+      feedRoot.dataset.feedTotal = String(state.totalPages);
+    }
+
+    feedRoot.dataset.feedPage = String(state.currentPage);
+
+    const nextPage = state.currentPage + 1;
+    const nextUrl = getPageUrl(nextPage);
+    if (nextUrl && (!state.totalPages || nextPage <= state.totalPages)) {
+      feedRoot.dataset.feedNext = nextUrl;
+    } else {
+      delete feedRoot.dataset.feedNext;
+    }
+
+    if (appended) {
+      if (!nextUrl || (state.totalPages && nextPage > state.totalPages)) {
+        markComplete();
+      } else {
+        setStatus("", { hidden: true });
+      }
+    } else if (!nextUrl || (state.totalPages && nextPage > state.totalPages)) {
+      markComplete();
+    } else {
+      setStatus("No more gifts to show right now. Check back soon.", { hidden: false });
+    }
+  } catch (error) {
+    console.error("[feed]", error);
+    setStatus("We couldn't load more gifts right now. Try again in a moment.", {
+      hidden: false,
+    });
+  } finally {
+    setLoading(false);
+  }
+}
+
+async function queueLoad() {
+  if (state.isLoading || state.done) return;
+  const nextPage = state.currentPage + 1 || 1;
+  if (state.totalPages && nextPage > state.totalPages) {
+    markComplete();
+    return;
+  }
+  await loadPage(nextPage);
+}
+
+if (loadMoreButton) {
+  loadMoreButton.addEventListener("click", () => {
+    queueLoad();
+  });
+}
+
+if ("IntersectionObserver" in window && sentinel && !state.done) {
+  observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          queueLoad();
+          break;
+        }
+      }
+    },
+    { rootMargin: "600px 0px" },
+  );
+  observer.observe(sentinel);
+}

--- a/public/assets/nav.js
+++ b/public/assets/nav.js
@@ -1,0 +1,124 @@
+const root = document.documentElement;
+root.classList.add("has-nav-js");
+
+const toggle = document.querySelector("[data-nav-toggle]");
+const panel = document.querySelector("[data-nav-panel]");
+
+if (toggle && panel) {
+  const focusableSelectors =
+    'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"]), input:not([disabled]), select:not([disabled]), textarea:not([disabled])';
+  const collapseMedia = window.matchMedia("(max-width: 900px)");
+  let isOpen = false;
+  let lastFocused = null;
+
+  function updatePanelAccessibility() {
+    if (collapseMedia.matches) {
+      panel.setAttribute("aria-hidden", isOpen ? "false" : "true");
+    } else {
+      panel.removeAttribute("aria-hidden");
+    }
+  }
+
+  function setState(open, { focus = true } = {}) {
+    if (isOpen === open) {
+      updatePanelAccessibility();
+      return;
+    }
+    isOpen = open;
+    toggle.setAttribute("aria-expanded", open ? "true" : "false");
+    panel.classList.toggle("is-open", open);
+    document.body.classList.toggle("nav-open", open);
+    updatePanelAccessibility();
+
+    if (open) {
+      lastFocused = document.activeElement;
+      const focusTarget = panel.querySelector(focusableSelectors) || toggle;
+      focusTarget.focus({ preventScroll: true });
+      return;
+    }
+
+    if (!focus) return;
+    const returnTarget = lastFocused && document.contains(lastFocused) ? lastFocused : toggle;
+    returnTarget.focus({ preventScroll: true });
+  }
+
+  function openNav() {
+    setState(true);
+  }
+
+  function closeNav(options = {}) {
+    setState(false, options);
+  }
+
+  toggle.addEventListener("click", (event) => {
+    event.preventDefault();
+    if (isOpen) {
+      closeNav();
+    } else {
+      openNav();
+    }
+  });
+
+  panel.addEventListener("click", (event) => {
+    if (!isOpen) return;
+    const anchor = event.target.closest("a[href]");
+    if (anchor) {
+      closeNav({ focus: false });
+    }
+  });
+
+  document.addEventListener("pointerdown", (event) => {
+    if (!isOpen) return;
+    if (panel.contains(event.target) || toggle.contains(event.target)) return;
+    closeNav({ focus: false });
+  });
+
+  function handleKeydown(event) {
+    if (!isOpen) return;
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeNav();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const focusable = panel.querySelectorAll(focusableSelectors);
+    if (!focusable.length) {
+      event.preventDefault();
+      toggle.focus({ preventScroll: true });
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    if (event.shiftKey) {
+      if (active === first || !panel.contains(active)) {
+        event.preventDefault();
+        last.focus({ preventScroll: true });
+      }
+      return;
+    }
+    if (active === last) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+    }
+  }
+
+  document.addEventListener("keydown", handleKeydown);
+
+  function handleBreakpointChange(event) {
+    if (!event.matches) {
+      closeNav({ focus: false });
+    } else {
+      updatePanelAccessibility();
+    }
+  }
+
+  if (typeof collapseMedia.addEventListener === "function") {
+    collapseMedia.addEventListener("change", handleBreakpointChange);
+  } else if (typeof collapseMedia.addListener === "function") {
+    collapseMedia.addListener(handleBreakpointChange);
+  }
+
+  updatePanelAccessibility();
+  toggle.setAttribute("aria-expanded", "false");
+}

--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -36,6 +36,18 @@ body {
   color-scheme: dark;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 @media (pointer: fine) and (hover: hover) {
   body {
     background-attachment: fixed;
@@ -80,8 +92,10 @@ main.wrap {
 }
 
 .header-inner {
+  position: relative;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 1.75rem;
 }
 
@@ -91,6 +105,67 @@ main.wrap {
   gap: 0.75rem;
   font-weight: 700;
   font-size: 1.05rem;
+}
+
+.site-nav-panel {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex: 1;
+  min-width: 0;
+}
+
+.site-nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(18, 7, 40, 0.4);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.site-nav-toggle:hover,
+.site-nav-toggle:focus-visible {
+  background: rgba(255, 61, 158, 0.12);
+  border-color: rgba(255, 61, 158, 0.65);
+  color: #ff8fcf;
+}
+
+.site-nav-toggle:focus-visible {
+  outline: 2px solid rgba(255, 143, 207, 0.7);
+  outline-offset: 2px;
+}
+
+.site-nav-toggle-icon {
+  display: grid;
+  gap: 6px;
+  place-items: center;
+}
+
+.site-nav-toggle-bar {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: currentColor;
+  border-radius: 999px;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+body.nav-open .site-nav-toggle-icon .site-nav-toggle-bar:nth-child(1) {
+  transform: translateY(8px) rotate(45deg);
+}
+
+body.nav-open .site-nav-toggle-icon .site-nav-toggle-bar:nth-child(2) {
+  opacity: 0;
+}
+
+body.nav-open .site-nav-toggle-icon .site-nav-toggle-bar:nth-child(3) {
+  transform: translateY(-8px) rotate(-45deg);
 }
 
 .logo {
@@ -117,6 +192,7 @@ main.wrap {
 .site-nav {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   flex-wrap: wrap;
   gap: 0.5rem;
 }
@@ -281,6 +357,146 @@ p {
   color: var(--fg);
 }
 
+.feed-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.feed-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.feed-header p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 520px;
+}
+
+.item-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.feed-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.feed-card {
+  background: rgba(17, 7, 32, 0.85);
+  border: 1px solid rgba(160, 122, 210, 0.22);
+  border-radius: 22px;
+  box-shadow: 0 15px 36px rgba(6, 0, 30, 0.35);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.feed-card-link {
+  display: flex;
+  flex-direction: column;
+  color: inherit;
+  height: 100%;
+}
+
+.feed-card-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.feed-card-media {
+  position: relative;
+  padding-top: 62%;
+  overflow: hidden;
+  background: rgba(15, 9, 32, 0.6);
+}
+
+.feed-card-media img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+.feed-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1.25rem;
+}
+
+.feed-card-title {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.45;
+}
+
+.feed-card-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.feed-card-price {
+  margin: 0;
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.feed-card-link:hover .feed-card-media img,
+.feed-card-link:focus-visible .feed-card-media img {
+  transform: scale(1.04);
+}
+
+.feed-load-more {
+  align-self: center;
+}
+
+.feed-status {
+  color: var(--muted);
+  font-size: 0.95rem;
+  min-height: 1.25rem;
+}
+
+.feed-status[hidden] {
+  display: none;
+}
+
+.feed-empty {
+  margin: 0;
+  color: var(--muted);
+  grid-column: 1 / -1;
+}
+
+.item-feed[data-feed-complete] .feed-load-more {
+  display: none;
+}
+
+.item-feed[data-feed-complete] .feed-status {
+  text-align: center;
+}
+
+.feed-sentinel {
+  width: 1px;
+  height: 1px;
+}
+
+.item-feed.is-loading .feed-load-more {
+  opacity: 0.65;
+  pointer-events: none;
+}
+
 .page-header {
   display: flex;
   flex-direction: column;
@@ -364,9 +580,46 @@ p {
 }
 
 @media (max-width: 900px) {
-  .header-inner {
+  html.has-nav-js .site-nav-panel {
+    position: absolute;
+    top: calc(100% + 0.75rem);
+    right: 0;
+    left: 0;
+    background: rgba(15, 9, 32, 0.96);
+    border: 1px solid var(--border);
+    border-radius: 22px;
+    padding: 1.25rem;
+    box-shadow: var(--shadow);
+    opacity: 0;
+    transform: translateY(-12px);
+    pointer-events: none;
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    z-index: 150;
+  }
+
+  html.has-nav-js .site-nav-panel.is-open,
+  html.has-nav-js body.nav-open .site-nav-panel {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  html.has-nav-js .site-nav {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: stretch;
+    gap: 0.35rem;
+  }
+
+  html.has-nav-js .site-nav a {
+    width: 100%;
+  }
+
+  html.has-nav-js .site-nav-toggle {
+    display: inline-flex;
+  }
+
+  body.nav-open {
+    overflow: hidden;
   }
 
   .hero {

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,5 +7,7 @@
   {% include "partials/header.html" %}
   <main class="wrap">{{ content|safe }}</main>
   {% include "partials/footer.html" %}
+  <script type="module" src="/assets/nav.js"></script>
+  <script type="module" src="/assets/feed.js"></script>
 </body>
 </html>

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -4,16 +4,32 @@
       <img src="/assets/grabgifts.svg" alt="grabgifts" class="logo" />
       <span class="brand-text">grabgifts</span>
     </a>
-    <nav class="site-nav" aria-label="Primary">
-      <a href="/">Home</a>
-      <a href="/for-him/">For Him</a>
-      <a href="/for-her/">For Her</a>
-      <a href="/tech/">Tech</a>
-      <a href="/gamers/">Gamers</a>
-      <a href="/fandom/">Fandom</a>
-      <a href="/homebody/">Homebody</a>
-      <a href="/guides/">Guides</a>
-      <a href="/faq/">FAQ</a>
-    </nav>
+    <button
+      class="site-nav-toggle"
+      type="button"
+      aria-expanded="false"
+      aria-controls="site-nav"
+      data-nav-toggle
+    >
+      <span class="sr-only">Toggle navigation</span>
+      <span aria-hidden="true" class="site-nav-toggle-icon">
+        <span class="site-nav-toggle-bar"></span>
+        <span class="site-nav-toggle-bar"></span>
+        <span class="site-nav-toggle-bar"></span>
+      </span>
+    </button>
+    <div class="site-nav-panel" data-nav-panel>
+      <nav class="site-nav" id="site-nav" aria-label="Primary">
+        <a href="/">Home</a>
+        <a href="/for-him/">For Him</a>
+        <a href="/for-her/">For Her</a>
+        <a href="/tech/">Tech</a>
+        <a href="/gamers/">Gamers</a>
+        <a href="/fandom/">Fandom</a>
+        <a href="/homebody/">Homebody</a>
+        <a href="/guides/">Guides</a>
+        <a href="/faq/">FAQ</a>
+      </nav>
+    </div>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- add a hamburger navigation toggle with responsive styling and accessibility helpers
- generate feed JSON pages during the build and render a scrolling feed with featured guides on the homepage
- ship lightweight front-end controllers for the nav menu and infinite item feed

## Testing
- npm run build *(fails: missing data/items.json in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc3648d1c8333aa2148f58fa74b24