### PR TITLE
Improve mobile navigation experience

### DIFF
--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -36,6 +36,23 @@ body {
   color-scheme: dark;
 }
 
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: rgba(9, 5, 18, 0.6);
+  backdrop-filter: blur(4px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  z-index: 90;
+}
+
+body.nav-open::before {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -595,6 +612,7 @@ p {
     pointer-events: none;
     transition: opacity 0.25s ease, transform 0.25s ease;
     z-index: 150;
+    display: block;
   }
 
   html.has-nav-js .site-nav-panel.is-open,
@@ -607,11 +625,25 @@ p {
   html.has-nav-js .site-nav {
     flex-direction: column;
     align-items: stretch;
-    gap: 0.35rem;
+    gap: 0.75rem;
   }
 
   html.has-nav-js .site-nav a {
     width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    border-radius: 16px;
+    border: 1px solid rgba(160, 122, 210, 0.35);
+    background: rgba(36, 20, 62, 0.6);
+    font-size: 1.02rem;
+    font-weight: 600;
+  }
+
+  html.has-nav-js .site-nav a:hover {
+    background: rgba(255, 61, 158, 0.18);
+    color: #ff3d9e;
   }
 
   html.has-nav-js .site-nav-toggle {
@@ -620,6 +652,10 @@ p {
 
   body.nav-open {
     overflow: hidden;
+  }
+
+  body.nav-open .site-header {
+    box-shadow: 0 18px 30px rgba(6, 0, 30, 0.35);
   }
 
   .hero {

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,10 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <link rel="stylesheet" href="/assets/theme.css">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#0a0810" />
+  <link rel="stylesheet" href="/assets/theme.css" />
 </head>
 <body>
   {% include "partials/header.html" %}


### PR DESCRIPTION
## Summary
- add responsive metadata to the base template so mobile browsers render the layout at the intended width
- polish the mobile navigation panel with spacing, styling, and a background overlay to present a clear hamburger menu
- dim the page behind the open menu for a more focused experience while keeping the header shadowed

## Testing
- npm run check *(fails: data/items.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc9a634288333b089edf583cc24f2