### PR TITLE
Enhance homepage feed with expandable guides and latest products

### DIFF
--- a/public/assets/home.js
+++ b/public/assets/home.js
@@ -1,0 +1,82 @@
+const guideSection = document.querySelector('[data-home-guides]');
+
+if (guideSection) {
+  const toggle = guideSection.querySelector('[data-home-guide-toggle="true"]');
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      const hiddenCards = guideSection.querySelectorAll('[data-home-guide-hidden="true"]');
+      hiddenCards.forEach((card) => {
+        card.removeAttribute('hidden');
+        card.removeAttribute('data-home-guide-hidden');
+      });
+      toggle.setAttribute('aria-expanded', 'true');
+      toggle.hidden = true;
+    });
+  }
+}
+
+function initProductSection(section) {
+  const grid = section.querySelector('[data-product-grid]');
+  const sentinel = section.querySelector('[data-product-sentinel]');
+  const source = section.querySelector('[data-product-source]');
+  if (!grid || !source) {
+    if (sentinel) sentinel.remove();
+    return;
+  }
+
+  let entries;
+  try {
+    const raw = source.textContent || '[]';
+    entries = JSON.parse(raw);
+  } catch (error) {
+    console.error('[home] Failed to parse product payload', error);
+    if (sentinel) sentinel.remove();
+    return;
+  }
+
+  if (!Array.isArray(entries) || !entries.length) {
+    if (sentinel) sentinel.remove();
+    return;
+  }
+
+  let index = 0;
+  const batchAttr = Number(section.getAttribute('data-product-batch'));
+  const batchSize = Number.isFinite(batchAttr) && batchAttr > 0 ? batchAttr : 6;
+  let observer = null;
+
+  function appendBatch() {
+    const next = entries.slice(index, index + batchSize);
+    next.forEach((markup) => {
+      if (typeof markup === 'string' && markup.trim()) {
+        grid.insertAdjacentHTML('beforeend', markup);
+      }
+    });
+    index += next.length;
+    if (index >= entries.length) {
+      if (observer) observer.disconnect();
+      if (sentinel) sentinel.remove();
+    }
+  }
+
+  if ('IntersectionObserver' in window && sentinel) {
+    observer = new IntersectionObserver(
+      (records) => {
+        for (const record of records) {
+          if (record.isIntersecting) {
+            appendBatch();
+            break;
+          }
+        }
+      },
+      { rootMargin: '400px 0px' },
+    );
+    observer.observe(sentinel);
+  } else {
+    appendBatch();
+  }
+}
+
+const productSection = document.querySelector('[data-home-products]');
+if (productSection) {
+  initProductSection(productSection);
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,5 +12,6 @@
   {% include "partials/footer.html" %}
   <script type="module" src="/assets/nav.js"></script>
   <script type="module" src="/assets/feed.js"></script>
+  <script type="module" src="/assets/home.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update the homepage generator to sort guides by recency, hide extras behind a “see more” control, and surface the newest product cards with lazy expansion
- add a reusable product preview card helper plus ISO timestamp parsing to support the new layout and feed data
- load a lightweight home.js module so the guides button reveals hidden cards and additional products stream in automatically, and include the script in the base template

## Testing
- python -m compileall giftgrab
- npm run check *(fails: missing data/items.json in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd1aad0448333b10c50aaff8aba29