### PR TITLE
Improve head metadata, ghost button, and footer

### DIFF
--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -354,10 +354,14 @@ a.button {
   background: transparent;
   border: 1px solid rgba(255, 79, 184, 0.55);
   box-shadow: none;
+  color: var(--fg);
 }
 
-.button-ghost:hover {
+.button-ghost:hover,
+.button-ghost:focus-visible {
   background: var(--accent-soft);
+  border-color: var(--accent-strong);
+  color: var(--accent-strong);
 }
 
 h1,
@@ -722,19 +726,57 @@ p {
 }
 
 .footer-inner {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.75rem);
+  align-items: start;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.footer-brand {
   display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 360px;
+}
+
+.footer-brand .brand {
   align-items: center;
-  justify-content: space-between;
-  gap: 1.5rem;
-  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.footer-tagline {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.footer-links {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: flex-start;
 }
 
 .footer-nav {
-  display: flex;
+  width: 100%;
+}
+
+.footer-link-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
   gap: 0.5rem;
 }
 
-.site-footer p {
+.footer-link-list a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.footer-meta {
   margin: 0;
   color: var(--muted);
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#0a0810" />
   <link rel="stylesheet" href="/assets/theme.css" />
+  {{ head|safe }}
 </head>
 <body>
   {% include "partials/header.html" %}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -1,12 +1,23 @@
 <footer class="site-footer">
   <div class="wrap footer-inner">
-    <a class="brand" href="/">
-      <img src="/assets/grabgifts.svg" alt="grabgifts" class="logo sm" />
-    </a>
-    <nav aria-label="Footer" class="footer-nav">
-      <a href="/guides/">Guides</a>
-      <a href="/faq/">FAQ / Disclosure</a>
-    </nav>
-    <p>© grabgifts</p>
+    <div class="footer-brand">
+      <a class="brand" href="/">
+        <img src="/assets/grabgifts.svg" alt="grabgifts" class="logo sm" />
+        <span class="brand-text">grabgifts</span>
+      </a>
+      <p class="footer-tagline">Daily gift drops, curated without the clutter.</p>
+    </div>
+    <div class="footer-links">
+      <nav aria-label="Footer" class="footer-nav">
+        <ul class="footer-link-list">
+          <li><a href="/guides/">Guides</a></li>
+          <li><a href="/surprise/">Spin up a surprise</a></li>
+          <li><a href="/changelog/">Live changelog</a></li>
+          <li><a href="/faq/">FAQ &amp; Disclosure</a></li>
+          <li><a href="/feed.xml">RSS feed</a></li>
+        </ul>
+      </nav>
+      <p class="footer-meta">© 2024 grabgifts. Curated recommendations refreshed daily.</p>
+    </div>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
- inject dynamic head metadata into the base template so generated pages emit titles, descriptions, canonical links, and JSON-LD
- improve the ghost hero button contrast and focus state for better accessibility
- refresh the footer layout with a richer navigation list and supporting copy

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdd5bedcd083339a9c2c7505685e59