### PR TITLE
Align hero theme and messaging with phase-one spec

### DIFF
--- a/giftgrab/config.py
+++ b/giftgrab/config.py
@@ -18,7 +18,8 @@ class SiteSettings:
     site_name: str = "Grab Gifts"
     base_url: str = "https://grabgifts.net"
     description: str = (
-        "Grab Gifts surfaces viral-ready Amazon finds with conversion copy and plug-and-play affiliate automation."
+        "Grab Gifts surfaces viral-ready Amazon finds with conversion copy and plug-and-play affiliate automation. "
+        "Launch scroll-stopping gift funnels that convert on autopilot."
     )
     adsense_client_id: str | None = None
     adsense_slot: str | None = None

--- a/giftgrab/generator.py
+++ b/giftgrab/generator.py
@@ -183,10 +183,14 @@ def load_settings() -> SiteSettings:
         description=_env(
             "SITE_DESCRIPTION",
             (
-                "GrabGifts curates trending products daily. Smart picks, clean layouts, zero clutter."
+                "Grab Gifts surfaces viral-ready Amazon finds with conversion copy and plug-and-play affiliate automation. "
+                "Launch scroll-stopping gift funnels that convert on autopilot."
             ),
         )
-        or "GrabGifts curates trending products daily. Smart picks, clean layouts, zero clutter.",
+        or (
+            "Grab Gifts surfaces viral-ready Amazon finds with conversion copy and plug-and-play affiliate automation. "
+            "Launch scroll-stopping gift funnels that convert on autopilot."
+        ),
         logo_url=_env("SITE_LOGO_URL"),
         twitter=_env("SITE_TWITTER"),
         facebook=_env("SITE_FACEBOOK"),

--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -1,7 +1,7 @@
 :root {
-  --bg-start: #16062c;
-  --bg-mid: #571362;
-  --bg-end: #05030d;
+  --bg-start: #2a0c6a;
+  --bg-mid: #9b0f62;
+  --bg-end: #0a0810;
   --bg-aurora-1: rgba(136, 88, 255, 0.55);
   --bg-aurora-2: rgba(255, 106, 207, 0.52);
   --bg-aurora-3: rgba(74, 213, 255, 0.32);
@@ -31,7 +31,7 @@ body {
   font-family: "Inter", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   font-size: 16px;
   line-height: 1.6;
-  background: linear-gradient(180deg, rgba(22, 6, 44, 0.98) 0%, rgba(31, 9, 55, 0.92) 55%, var(--bg-end) 100%);
+  background: linear-gradient(180deg, rgba(42, 12, 106, 0.96) 0%, rgba(155, 15, 98, 0.88) 55%, var(--bg-end) 100%);
   background-color: var(--bg-end);
   min-height: 100%;
   -webkit-font-smoothing: antialiased;

--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -5,9 +5,9 @@ import { priceNumber } from "./util.mjs";
 
 const IN = path.join("data", "items.json");
 const PUB = "public";
-const SITE_NAME = "GrabGifts";
+const SITE_NAME = "grabgifts";
 const SITE_DESCRIPTION =
-  "GrabGifts curates trending products daily. Smart picks, clean layouts, zero clutter.";
+  "Grab Gifts surfaces viral-ready Amazon finds with conversion copy and plug-and-play affiliate automation. Launch scroll-stopping gift funnels that convert on autopilot.";
 
 const BASE_TEMPLATE_PATH = path.join("templates", "base.html");
 const HEADER_PATH = path.join("templates", "partials", "header.html");


### PR DESCRIPTION
## Summary
- retune the global theme gradient to the required #2a0c6a → #9b0f62 → #0a0810 palette while preserving the aurora treatment
- update the default site description, generator defaults, and build script so the hero copy matches the two-line phase-one spec and the site name renders as lowercase grabgifts

## Testing
- `node tools/check_phase.mjs`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cddf482c80833380aed27db8061ed0