### PR TITLE
Implement immersive home layout and feed UX enhancements

### DIFF
--- a/public/assets/feed.js
+++ b/public/assets/feed.js
@@ -87,6 +87,8 @@ function initFeed(root) {
       seenIds: new Set(),
       isLoading: false,
       statusMessage: "",
+      hasVisited: false,
+      scrollTop: null,
       done,
     });
   }
@@ -379,6 +381,11 @@ function initFeed(root) {
       const previous = modes.get(activeModeId);
       if (previous) {
         previous.savedHtml = listEl.innerHTML;
+        if (typeof window !== "undefined") {
+          const top = typeof window.scrollY === "number" ? window.scrollY : window.pageYOffset || 0;
+          previous.scrollTop = top;
+        }
+        previous.hasVisited = true;
       }
     }
 
@@ -392,6 +399,16 @@ function initFeed(root) {
     mode.statusMessage = "";
     applyState(mode);
     updateObserver(mode);
+    if (mode.hasVisited && typeof mode.scrollTop === "number" && typeof window !== "undefined") {
+      const target = mode.scrollTop;
+      const scroll = () => window.scrollTo({ top: target });
+      if (typeof window.requestAnimationFrame === "function") {
+        window.requestAnimationFrame(scroll);
+      } else {
+        scroll();
+      }
+    }
+    mode.hasVisited = true;
   }
 
   tabs.forEach((tab) => {


### PR DESCRIPTION
## Summary
- rebuild the homepage generator to emit the aurora hero, guide reveal section, lazy-loaded product previews, and updated live feed wiring
- add generators for the guides index, surprise redirect, changelog timeline, and refreshed FAQ copy to complete the immersive layout
- enhance the feed module to remember per-tab scroll positions while keeping accessibility status updates intact

## Testing
- npm run build *(fails: data/items.json is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cde430cd7883338b005337245005c5