### PR TITLE
Add homepage stats and quality section

### DIFF
--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -314,6 +314,41 @@ body.nav-open .site-nav-toggle-icon .site-nav-toggle-bar:nth-child(3) {
   font-size: 1.05rem;
 }
 
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.hero-meta li {
+  flex: 1 1 180px;
+  min-width: 0;
+  padding: 0.85rem 1.15rem;
+  border-radius: 18px;
+  background: rgba(16, 7, 34, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 16px 34px rgba(0, 0, 0, 0.28);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.hero-meta__value {
+  font-size: clamp(1.3rem, 4vw, 1.85rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.hero-meta__label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
@@ -384,6 +419,42 @@ p {
   list-style: none;
   padding: 0;
   margin: 0;
+}
+
+.quality-section {
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: rgba(15, 6, 32, 0.72);
+  box-shadow: var(--shadow);
+  padding: clamp(1.75rem, 4vw, 2.75rem);
+}
+
+.quality-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.quality-card {
+  background: rgba(12, 5, 28, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
+  padding: clamp(1rem, 3vw, 1.6rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.28);
+}
+
+.quality-card h3 {
+  margin: 0;
+  font-size: 1.08rem;
+}
+
+.quality-card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.65;
 }
 
 .guide-grid {
@@ -979,6 +1050,10 @@ p {
 }
 
 @media (max-width: 600px) {
+  .hero-meta li {
+    flex: 1 1 100%;
+  }
+
   .hero-actions {
     flex-direction: column;
     align-items: stretch;


### PR DESCRIPTION
## Summary
- surface catalog metrics and last refresh details on the hero to reinforce freshness
- add a "Why shoppers trust grabgifts" section with data-backed copy about coverage and trends
- extend the shared theme to style the new hero stats and trust cards responsively

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cde9d18cec8333917037bfa3db623a