### PR TITLE
Fix navigation links to category pages

### DIFF
--- a/scripts/build-sitemap.mjs
+++ b/scripts/build-sitemap.mjs
@@ -11,12 +11,12 @@ const SITEMAP_FILE = path.join(PUBLIC_DIR, "sitemap.xml");
 const STATIC_ROUTES = [
   "/",
   "/guides",
-  "/for-him",
-  "/for-her",
-  "/techy",
-  "/gamers",
-  "/fandom",
-  "/homebody",
+  "/categories/for-him",
+  "/categories/for-her",
+  "/categories/for-a-techy",
+  "/categories/for-gamers",
+  "/categories/for-fandom",
+  "/categories/homebody-upgrades",
 ];
 
 const formatUrl = (base, route) => {

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -21,12 +21,12 @@
     <div class="site-nav-panel" data-nav-panel>
       <nav class="site-nav" id="site-nav" aria-label="Primary">
         <a href="/">Home</a>
-        <a href="/for-him/">For Him</a>
-        <a href="/for-her/">For Her</a>
-        <a href="/tech/">Tech</a>
-        <a href="/gamers/">Gamers</a>
-        <a href="/fandom/">Fandom</a>
-        <a href="/homebody/">Homebody</a>
+        <a href="/categories/for-him/">For Him</a>
+        <a href="/categories/for-her/">For Her</a>
+        <a href="/categories/for-a-techy/">Tech</a>
+        <a href="/categories/for-gamers/">Gamers</a>
+        <a href="/categories/for-fandom/">Fandom</a>
+        <a href="/categories/homebody-upgrades/">Homebody</a>
         <a href="/guides/">Guides</a>
         <a href="/faq/">FAQ</a>
       </nav>


### PR DESCRIPTION
## Summary
- update the primary navigation links so each menu item points at the generated category URL
- adjust the sitemap static route list to match the new category destinations

## Testing
- npm run check *(fails: requires data/items.json which is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cded54fdc0833391879022481e24af