### PR TITLE
Add supplemental static pages and update navigation

### DIFF
--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -10,6 +10,9 @@
     <div class="footer-links">
       <nav aria-label="Footer" class="footer-nav">
         <ul class="footer-link-list">
+          <li><a href="/about/">About</a></li>
+          <li><a href="/how-we-curate/">How we curate</a></li>
+          <li><a href="/contact/">Contact</a></li>
           <li><a href="/guides/">Guides</a></li>
           <li><a href="/surprise/">Spin up a surprise</a></li>
           <li><a href="/changelog/">Live changelog</a></li>

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -28,6 +28,9 @@
         <a href="/categories/for-fandom/">Fandom</a>
         <a href="/categories/homebody-upgrades/">Homebody</a>
         <a href="/guides/">Guides</a>
+        <a href="/about/">About</a>
+        <a href="/how-we-curate/">How we curate</a>
+        <a href="/contact/">Contact</a>
         <a href="/faq/">FAQ</a>
       </nav>
     </div>

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -48,6 +48,7 @@ def test_generator_outputs_required_files(tmp_path, monkeypatch):
     repository.ingest(products)
     monkeypatch.setenv("SITE_BASE_URL", "https://example.com")
     monkeypatch.setenv("AMAZON_ASSOCIATE_TAG", "testtag-20")
+    monkeypatch.setenv("SITE_CONTACT_EMAIL", "hello@example.com")
     output_dir = tmp_path / "public"
     guides = generate_guides(repository, limit=15)
     generator = SiteGenerator(output_dir=output_dir)
@@ -55,7 +56,9 @@ def test_generator_outputs_required_files(tmp_path, monkeypatch):
     generator.build(products=stored_products, guides=guides)
 
     sitemap = (output_dir / "sitemap.xml").read_text(encoding="utf-8")
-    assert sitemap.count("<url>") >= 16
+    assert sitemap.count("<url>") >= 19
+    for slug in ("/about/", "/how-we-curate/", "/contact/"):
+        assert f"<loc>https://example.com{slug}</loc>" in sitemap
     assert (output_dir / "rss.xml").exists()
     assert (output_dir / "robots.txt").exists()
 
@@ -63,6 +66,13 @@ def test_generator_outputs_required_files(tmp_path, monkeypatch):
     product_html = (output_dir / "products" / amazon_product.slug / "index.html").read_text(encoding="utf-8")
     assert 'rel="sponsored nofollow noopener"' in product_html
     assert "tag=testtag-20" in product_html
+
+    about_html = (output_dir / "about" / "index.html").read_text(encoding="utf-8")
+    assert "About grabgifts" in about_html
+    contact_html = (output_dir / "contact" / "index.html").read_text(encoding="utf-8")
+    assert "hello@example.com" in contact_html
+    curation_html = (output_dir / "how-we-curate" / "index.html").read_text(encoding="utf-8")
+    assert "How we curate" in curation_html
 
 
 def test_polish_guide_title_removes_for_a_and_right_now():

--- a/tools/check_phase.mjs
+++ b/tools/check_phase.mjs
@@ -230,6 +230,17 @@ async function main() {
     throw new Error("/faq/index.html is missing");
   }
 
+  const supplementalPages = [
+    ["/about/", path.join(PUBLIC_DIR, "about", "index.html")],
+    ["/how-we-curate/", path.join(PUBLIC_DIR, "how-we-curate", "index.html")],
+    ["/contact/", path.join(PUBLIC_DIR, "contact", "index.html")],
+  ];
+  for (const [slug, filePath] of supplementalPages) {
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`${slug} index missing`);
+    }
+  }
+
   const sitemapPath = path.join(PUBLIC_DIR, "sitemap.xml");
   if (!fs.existsSync(sitemapPath)) {
     throw new Error("sitemap.xml missing");
@@ -237,6 +248,12 @@ async function main() {
   const sitemap = fs.readFileSync(sitemapPath, "utf8");
   if (!/\<loc\>[^<]*\/faq\/\<\/loc\>/.test(sitemap)) {
     throw new Error("/faq/ not listed in sitemap.xml");
+  }
+  for (const [slug] of supplementalPages) {
+    const pattern = new RegExp(`\\<loc\\>[^<]*${slug.replace(/\//g, "\\/")}\\<\\/loc\\>`);
+    if (!pattern.test(sitemap)) {
+      throw new Error(`${slug} not listed in sitemap.xml`);
+    }
   }
 
   const imagesToCheck = Array.from(productImages).slice(0, PRODUCT_IMAGE_LIMIT);


### PR DESCRIPTION
## Summary
- add generator routines for /about, /how-we-curate, and /contact while refreshing the FAQ contact link
- expose the new supplemental destinations in the site header and footer
- extend automated QA checks and generator tests to cover the extra pages

## Testing
- pytest
- node tools/check_phase.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cdeeae1e10833386d3ae9d0c15dd2b