### PR TITLE
Add catalog stats reporting command

### DIFF
--- a/giftgrab/amazon.py
+++ b/giftgrab/amazon.py
@@ -112,6 +112,14 @@ def search(keywords: Iterable[str], limit: int = 10) -> List[dict]:
     credentials = _ensure_credentials()
     if credentials is None:
         return []
+    return _search_with_credentials(credentials, keywords=keywords, limit=limit)
+
+
+def _search_with_credentials(
+    credentials: AmazonCredentials, *, keywords: Iterable[str], limit: int
+) -> List[dict]:
+    """Perform a search against the PA-API using explicit credentials."""
+
     query = " ".join(str(keyword) for keyword in keywords if keyword)
     body = json.dumps(
         {
@@ -201,3 +209,15 @@ def search(keywords: Iterable[str], limit: int = 10) -> List[dict]:
             }
         )
     return results
+
+
+class AmazonProductClient:
+    """Thin client wrapper used by retailer adapters."""
+
+    def __init__(self, credentials: AmazonCredentials) -> None:
+        self.credentials = credentials
+
+    def search_items(self, *, keywords: Iterable[str], item_count: int) -> List[dict]:
+        return _search_with_credentials(
+            self.credentials, keywords=keywords, limit=item_count
+        )

--- a/giftgrab/reporting.py
+++ b/giftgrab/reporting.py
@@ -1,0 +1,220 @@
+"""Reporting helpers for summarizing catalog and guide health."""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Sequence
+
+from .models import Guide, Product
+
+
+@dataclass
+class InventoryStats:
+    """Aggregate metrics describing the current product catalog."""
+
+    total_products: int
+    sources: list[tuple[str, int]]
+    top_categories: list[tuple[str, int]]
+    min_price: float | None
+    max_price: float | None
+    average_price: float | None
+    priced_products: int
+    missing_images: int
+    missing_descriptions: int
+
+
+@dataclass
+class GuideStats:
+    """Summaries for the generated roundup guides."""
+
+    total_guides: int
+    total_products: int
+    average_products: float | None
+    recent_count: int
+    recent_days: int
+    latest_created_at: str | None
+
+
+def summarize_inventory(products: Sequence[Product], *, top_categories: int = 5) -> InventoryStats:
+    """Compute aggregate statistics for the provided catalog."""
+
+    total = len(products)
+    source_counter: Counter[str] = Counter()
+    category_counter: Counter[str] = Counter()
+    prices: list[float] = []
+    missing_images = 0
+    missing_descriptions = 0
+
+    for product in products:
+        source = (product.source or "unknown").strip() or "unknown"
+        source_counter[source] += 1
+        if product.category:
+            category_counter[str(product.category)] += 1
+        if product.price is not None:
+            prices.append(float(product.price))
+        if not product.image:
+            missing_images += 1
+        description = (product.description or "").strip()
+        if not description:
+            missing_descriptions += 1
+
+    priced_products = len(prices)
+    min_price = min(prices) if prices else None
+    max_price = max(prices) if prices else None
+    average_price = (sum(prices) / priced_products) if priced_products else None
+
+    sources = sorted(source_counter.items(), key=lambda item: (-item[1], item[0]))
+    category_limit = max(top_categories, 0)
+    categories_sorted = sorted(
+        category_counter.items(), key=lambda item: (-item[1], item[0])
+    )
+    if category_limit:
+        categories_sorted = categories_sorted[:category_limit]
+    else:
+        categories_sorted = []
+
+    return InventoryStats(
+        total_products=total,
+        sources=sources,
+        top_categories=categories_sorted,
+        min_price=min_price,
+        max_price=max_price,
+        average_price=average_price,
+        priced_products=priced_products,
+        missing_images=missing_images,
+        missing_descriptions=missing_descriptions,
+    )
+
+
+def summarize_guides(
+    guides: Sequence[Guide], *, recent_days: int = 7, now: datetime | None = None
+) -> GuideStats:
+    """Compute aggregate metrics for generated guides."""
+
+    total_guides = len(guides)
+    total_products = sum(len(guide.products) for guide in guides)
+    average_products = (total_products / total_guides) if total_guides else None
+
+    reference = now or datetime.now(timezone.utc)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=timezone.utc)
+    cutoff = reference - timedelta(days=max(recent_days, 0))
+
+    recent_count = 0
+    latest_created: datetime | None = None
+    for guide in guides:
+        created = _parse_iso_datetime(guide.created_at)
+        if not created:
+            continue
+        if created >= cutoff:
+            recent_count += 1
+        if latest_created is None or created > latest_created:
+            latest_created = created
+
+    latest_text = latest_created.isoformat() if latest_created else None
+    return GuideStats(
+        total_guides=total_guides,
+        total_products=total_products,
+        average_products=average_products,
+        recent_count=recent_count,
+        recent_days=recent_days,
+        latest_created_at=latest_text,
+    )
+
+
+def generate_stats_report(
+    *,
+    products: Sequence[Product],
+    guides: Sequence[Guide],
+    top_categories: int = 5,
+    recent_days: int = 7,
+    now: datetime | None = None,
+) -> str:
+    """Return a formatted report summarizing catalog and guide health."""
+
+    inventory = summarize_inventory(products, top_categories=top_categories)
+    guide_stats = summarize_guides(guides, recent_days=recent_days, now=now)
+
+    lines: list[str] = ["Inventory Summary"]
+    if inventory.total_products == 0:
+        lines.append("  No products available.")
+    else:
+        lines.append(f"  Total products: {inventory.total_products}")
+        if inventory.sources:
+            sources_text = ", ".join(
+                f"{name} ({count})" for name, count in inventory.sources
+            )
+            lines.append(f"  Sources: {sources_text}")
+        if inventory.top_categories:
+            categories_text = ", ".join(
+                f"{category} ({count})" for category, count in inventory.top_categories
+            )
+            lines.append(f"  Top categories: {categories_text}")
+        if inventory.priced_products:
+            price_line = _format_price_summary(
+                inventory.min_price, inventory.max_price, inventory.average_price
+            )
+            item_label = "item" if inventory.priced_products == 1 else "items"
+            lines.append(
+                f"  Pricing: {price_line} across {inventory.priced_products} {item_label}"
+            )
+        lines.append(f"  Missing images: {inventory.missing_images}")
+        lines.append(f"  Missing descriptions: {inventory.missing_descriptions}")
+
+    lines.append("")
+    lines.append("Guide Summary")
+    if guide_stats.total_guides == 0:
+        lines.append("  No guides have been generated yet.")
+    else:
+        lines.append(f"  Total guides: {guide_stats.total_guides}")
+        lines.append(f"  Total referenced products: {guide_stats.total_products}")
+        if guide_stats.average_products is not None:
+            lines.append(
+                f"  Avg products per guide: {guide_stats.average_products:.1f}"
+            )
+        lines.append(
+            f"  Guides updated in last {guide_stats.recent_days} days: {guide_stats.recent_count}"
+        )
+        if guide_stats.latest_created_at:
+            lines.append(
+                f"  Most recent guide published: {guide_stats.latest_created_at}"
+            )
+
+    return "\n".join(lines)
+
+
+def _parse_iso_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_price_summary(
+    min_price: float | None, max_price: float | None, average_price: float | None
+) -> str:
+    parts: list[str] = []
+    if min_price is not None and max_price is not None:
+        if abs(min_price - max_price) < 1e-9:
+            parts.append(_format_currency(min_price))
+        else:
+            parts.append(f"{_format_currency(min_price)}–{_format_currency(max_price)}")
+    elif min_price is not None:
+        parts.append(f"from {_format_currency(min_price)}")
+    elif max_price is not None:
+        parts.append(f"up to {_format_currency(max_price)}")
+
+    if average_price is not None:
+        parts.append(f"(avg {_format_currency(average_price)})")
+
+    return " ".join(parts) if parts else "no pricing data"
+
+
+def _format_currency(value: float) -> str:
+    return f"${value:,.2f}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,78 @@
+import argparse
+from datetime import datetime, timezone
+
+import pytest
+
+from giftgrab.cli import handle_stats
+from giftgrab.models import Guide, Product
+from giftgrab.repository import ProductRepository
+
+
+def build_sample_product(product_id: str) -> Product:
+    return Product(
+        id=product_id,
+        title=f"Sample {product_id}",
+        url=f"https://example.com/{product_id}",
+        image="https://example.com/image.jpg",
+        price=19.99,
+        price_text="$19.99",
+        currency="USD",
+        brand="Brand",
+        category="Gifts",
+        rating=4.5,
+        rating_count=10,
+        source="amazon",
+        description="Sample product",
+    )
+
+
+def test_handle_stats_prints_report(monkeypatch, tmp_path, capsys):
+    data_dir = tmp_path / "data"
+    repository = ProductRepository(base_dir=data_dir)
+    products = [build_sample_product("p1")]
+    repository.save_products(products)
+    guides = [
+        Guide(
+            slug="guide-1",
+            title="Guide One",
+            description="Desc",
+            products=products,
+            created_at=datetime(2024, 1, 1, tzinfo=timezone.utc).isoformat(),
+        )
+    ]
+    repository.save_guides(guides)
+
+    monkeypatch.setattr("giftgrab.cli.ProductRepository", lambda: repository)
+
+    captured = {}
+
+    def fake_generate_stats_report(*, products, guides, top_categories, recent_days):
+        captured["products"] = products
+        captured["guides"] = guides
+        captured["top_categories"] = top_categories
+        captured["recent_days"] = recent_days
+        return "REPORT"
+
+    monkeypatch.setattr("giftgrab.cli.generate_stats_report", fake_generate_stats_report)
+
+    args = argparse.Namespace(top_categories=3, recent_days=10)
+    handle_stats(args)
+
+    output = capsys.readouterr().out.strip()
+    assert output == "REPORT"
+    assert len(captured["products"]) == 1
+    assert captured["guides"][0].slug == "guide-1"
+    assert captured["top_categories"] == 3
+    assert captured["recent_days"] == 10
+
+
+def test_handle_stats_validates_arguments():
+    args = argparse.Namespace(top_categories=-1, recent_days=7)
+    with pytest.raises(SystemExit) as excinfo:
+        handle_stats(args)
+    assert "--top-categories cannot be negative" in str(excinfo.value)
+
+    args = argparse.Namespace(top_categories=1, recent_days=0)
+    with pytest.raises(SystemExit) as excinfo:
+        handle_stats(args)
+    assert "--recent-days must be at least 1" in str(excinfo.value)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,144 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from giftgrab.models import Guide, Product
+from giftgrab.reporting import (
+    generate_stats_report,
+    summarize_guides,
+    summarize_inventory,
+)
+
+
+def build_products() -> list[Product]:
+    return [
+        Product(
+            id="p1",
+            title="Item One",
+            url="https://example.com/1",
+            image="https://example.com/1.jpg",
+            price=25.0,
+            price_text="$25.00",
+            currency="USD",
+            brand="BrandA",
+            category="Cozy Home",
+            rating=4.5,
+            rating_count=10,
+            source="amazon",
+            description="Great gift",
+        ),
+        Product(
+            id="p2",
+            title="Item Two",
+            url="https://example.com/2",
+            image=None,
+            price=40.0,
+            price_text="$40.00",
+            currency="USD",
+            brand="BrandB",
+            category="Cozy Home",
+            rating=4.0,
+            rating_count=5,
+            source="amazon",
+            description="",
+        ),
+        Product(
+            id="p3",
+            title="Item Three",
+            url="https://example.com/3",
+            image=None,
+            price=None,
+            price_text=None,
+            currency=None,
+            brand="BrandC",
+            category="Desk Gear",
+            rating=None,
+            rating_count=None,
+            source="ebay",
+            description=None,
+        ),
+    ]
+
+
+def test_summarize_inventory_counts_categories_and_missing_fields():
+    products = build_products()
+    stats = summarize_inventory(products, top_categories=3)
+
+    assert stats.total_products == 3
+    assert stats.sources == [("amazon", 2), ("ebay", 1)]
+    assert stats.top_categories == [("Cozy Home", 2), ("Desk Gear", 1)]
+    assert stats.priced_products == 2
+    assert stats.missing_images == 2
+    assert stats.missing_descriptions == 2
+    assert stats.min_price == pytest.approx(25.0)
+    assert stats.max_price == pytest.approx(40.0)
+    assert stats.average_price == pytest.approx(32.5)
+
+
+def test_summarize_guides_tracks_recent_activity():
+    products = build_products()
+    now = datetime(2024, 1, 15, tzinfo=timezone.utc)
+    guides = [
+        Guide(
+            slug="guide-1",
+            title="Guide One",
+            description="A great set",
+            products=[products[0], products[1]],
+            created_at=(now - timedelta(days=2)).isoformat(),
+        ),
+        Guide(
+            slug="guide-2",
+            title="Guide Two",
+            description="Another",
+            products=[products[2]],
+            created_at=(now - timedelta(days=10)).isoformat(),
+        ),
+    ]
+
+    stats = summarize_guides(guides, recent_days=7, now=now)
+
+    assert stats.total_guides == 2
+    assert stats.total_products == 3
+    assert stats.average_products == pytest.approx(1.5)
+    assert stats.recent_count == 1
+    assert stats.latest_created_at == (now - timedelta(days=2)).isoformat()
+
+
+def test_generate_stats_report_formats_summary_sections():
+    products = build_products()
+    now = datetime(2024, 1, 15, tzinfo=timezone.utc)
+    guides = [
+        Guide(
+            slug="guide-1",
+            title="Guide One",
+            description="A great set",
+            products=[products[0], products[1]],
+            created_at=(now - timedelta(days=2)).isoformat(),
+        ),
+        Guide(
+            slug="guide-2",
+            title="Guide Two",
+            description="Another",
+            products=[products[2]],
+            created_at=(now - timedelta(days=10)).isoformat(),
+        ),
+    ]
+
+    report = generate_stats_report(
+        products=products,
+        guides=guides,
+        top_categories=2,
+        recent_days=7,
+        now=now,
+    )
+
+    assert "Inventory Summary" in report
+    assert "Total products: 3" in report
+    assert "Sources: amazon (2), ebay (1)" in report
+    assert "Top categories: Cozy Home (2), Desk Gear (1)" in report
+    assert "Pricing: $25.00–$40.00 (avg $32.50) across 2 items" in report
+    assert "Missing images: 2" in report
+    assert "Guide Summary" in report
+    assert "Total guides: 2" in report
+    assert "Guides updated in last 7 days: 1" in report
+    assert (now - timedelta(days=2)).isoformat() in report


### PR DESCRIPTION
## Summary
- add reporting helpers to compute inventory and guide health metrics
- expose a new `stats` CLI subcommand that prints a catalog snapshot
- provide thin Amazon and eBay client wrappers so adapters can invoke shared search helpers and add focused tests for the new reporting flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdf203311c83338dcea5cd3c05de6f