### PR TITLE
Improve homepage storytelling and product blurbs

### DIFF
--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -365,6 +365,41 @@ body.nav-open .site-nav-toggle-icon .site-nav-toggle-bar:nth-child(3) {
   margin-top: 0.5rem;
 }
 
+.hero-support {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.hero-support__lede {
+  margin: 0;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+.hero-support__list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.hero-support__list li {
+  background: rgba(16, 7, 34, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 0.9rem 1.1rem;
+  color: var(--muted);
+  line-height: 1.6;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.22);
+}
+
 .button,
 .button:visited,
 a.button {
@@ -464,6 +499,69 @@ p {
   margin: 0;
   color: var(--muted);
   line-height: 1.65;
+}
+
+.press-section {
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: rgba(12, 5, 28, 0.78);
+  box-shadow: var(--shadow);
+  padding: clamp(1.75rem, 4vw, 2.75rem);
+}
+
+.press-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.press-card {
+  background: rgba(16, 7, 34, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 20px;
+  padding: clamp(1.15rem, 3vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  min-height: 100%;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.26);
+}
+
+.press-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.press-logo img {
+  max-height: 36px;
+  width: auto;
+  filter: grayscale(0.1);
+}
+
+.press-quote {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+  font-size: 1rem;
+}
+
+.press-outlet {
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.press-outlet a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.press-outlet a:hover {
+  color: #ff7ad3;
 }
 
 .guide-grid {
@@ -1066,6 +1164,10 @@ p {
   .hero-actions {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .hero-support__list {
+    grid-template-columns: 1fr;
   }
 
   .timeline li {


### PR DESCRIPTION
## Summary
- highlight the homepage hero with a refreshed support list and a new press testimonial section
- load press mentions from defaults or overrides and style the new blocks for consistency
- refine product blurbs with cleaner focus targets and descriptor phrasing for each category

## Testing
- `python -m giftgrab.cli roundups --limit 15`


------
https://chatgpt.com/codex/tasks/task_e_68cdfc84815083338178ee9a85944962