### PR TITLE
Allow price text merges and avoid persisting failed ingests

### DIFF
--- a/giftgrab/models.py
+++ b/giftgrab/models.py
@@ -121,6 +121,13 @@ def merge_products(existing: Iterable[Product], incoming: Iterable[Product]) -> 
             stored.price_text = product.price_text
             stored.currency = product.currency
             updated = True
+        else:
+            if product.price_text and product.price_text != stored.price_text:
+                stored.price_text = product.price_text
+                updated = True
+            if product.currency and product.currency != stored.currency:
+                stored.currency = product.currency
+                updated = True
         if product.brand and product.brand != stored.brand:
             stored.brand = product.brand
             updated = True

--- a/giftgrab/repository.py
+++ b/giftgrab/repository.py
@@ -79,11 +79,11 @@ class ProductRepository:
             accepted.append(product)
             seen_map[product.id] = reference.isoformat()
         merged = merge_products(existing, accepted)
-        self.save_products(merged)
-        self._save_seen(seen_map)
         count = len(merged)
         if count < 50:
             raise RuntimeError(f"Inventory too small: {count}")
+        self.save_products(merged)
+        self._save_seen(seen_map)
         return merged
 
     def _load_seen(self) -> dict[str, str]:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from giftgrab.models import Product
+from giftgrab.models import Product, merge_products
 from giftgrab.repository import ProductRepository
 
 
@@ -24,6 +24,23 @@ def make_product(idx: int) -> Product:
     )
 
 
+def test_merge_products_updates_textual_price_fields_without_numeric_change():
+    existing_product = make_product(1)
+    original_updated_at = existing_product.updated_at
+    incoming = make_product(1)
+    incoming.price = None
+    incoming.price_text = "£21.00"
+    incoming.currency = "GBP"
+
+    merged = merge_products([existing_product], [incoming])
+    merged_product = merged[0]
+
+    assert merged_product.price == existing_product.price
+    assert merged_product.price_text == "£21.00"
+    assert merged_product.currency == "GBP"
+    assert merged_product.updated_at != original_updated_at
+
+
 def test_ingest_enforces_cooldown(tmp_path):
     repo = ProductRepository(base_dir=tmp_path)
     now = datetime.now(timezone.utc)
@@ -42,3 +59,16 @@ def test_ingest_requires_minimum_inventory(tmp_path):
     products = [make_product(i) for i in range(40)]
     with pytest.raises(RuntimeError):
         repo.ingest(products)
+
+
+def test_ingest_failure_does_not_persist_files(tmp_path):
+    repo = ProductRepository(base_dir=tmp_path)
+    items_before = repo.items_file.read_text(encoding="utf-8")
+    seen_before = repo.seen_file.read_text(encoding="utf-8")
+
+    products = [make_product(i) for i in range(40)]
+    with pytest.raises(RuntimeError):
+        repo.ingest(products)
+
+    assert repo.items_file.read_text(encoding="utf-8") == items_before
+    assert repo.seen_file.read_text(encoding="utf-8") == seen_before


### PR DESCRIPTION
## Summary
- allow `merge_products` to refresh price text and currency even when only textual pricing data changes
- guard `ProductRepository.ingest` so undersized inventories abort before writing catalog or seen history
- extend repository tests to cover price-text merges and to assert failing ingests leave JSON files untouched

## Testing
- pytest tests/test_repository.py

------
https://chatgpt.com/codex/tasks/task_e_68ce0411543483338455a0abfb491c8b