### PR TITLE
Add CLI tooling and tests for eBay Browse integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ All entry points live in `giftgrab/cli.py` and are executed with `python -m gift
 | `python -m giftgrab.cli update` | Fetch products from eBay, merge curated JSON feeds under `data/retailers/`, enforce the 30-day item cooldown, and persist the catalog to `data/items.json`. Builds fail if fewer than 50 products remain. |
 | `python -m giftgrab.cli roundups --limit 15` | Generate at least fifteen roundup guides, update `data/topics_history.json`, and render the static site to `public/` with canonical URLs, WebSite JSON-LD, ItemList JSON-LD for each guide, and Product JSON-LD for every card/page. |
 | `python -m giftgrab.cli check` | Lightweight QA gate that ensures the catalog has ≥50 products, ≥15 guides, no duplicate slugs, and that `public/sitemap.xml`, `public/robots.txt`, and `public/rss.xml` exist. |
+| `python -m giftgrab.cli ebay "coffee gifts" --limit 5 --marketplace EBAY_US` | Run a quick Browse API query to validate credentials and inspect normalized eBay inventory. |
 
 The recommended Netlify build command is:
 
@@ -35,6 +36,7 @@ The static site is written to `public/` and includes `guides/`, `categories/`, `
 
 - `EBAY_CLIENT_ID` and `EBAY_CLIENT_SECRET` – required to call the eBay Browse API.
 - `EBAY_CAMPAIGN_ID` (optional) – appended to outbound eBay URLs when present.
+- `EBAY_MARKETPLACE_ID` (optional) – overrides the default `EBAY_US` marketplace header for Browse API requests.
 - `AMAZON_PAAPI_ACCESS_KEY` and `AMAZON_PAAPI_SECRET_KEY` (optional) – enable Amazon PA-API requests.
 - `AMAZON_ASSOCIATE_TAG` – applied to every Amazon URL; defaults to the site’s required tag when unset.
 - `AMAZON_MARKETPLACE` (optional) – defaults to `www.amazon.com`.

--- a/tests/test_ebay.py
+++ b/tests/test_ebay.py
@@ -1,0 +1,61 @@
+import json
+
+import pytest
+
+from giftgrab import ebay
+
+
+class DummyResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_search_parses_items(monkeypatch):
+    payload = {
+        "itemSummaries": [
+            {
+                "itemId": "123",
+                "title": "Coffee Grinder",
+                "itemWebUrl": "https://www.ebay.com/itm/123",
+                "image": {"imageUrl": "https://example.com/image.jpg"},
+                "price": {"value": "19.99", "currency": "USD"},
+                "brand": {"value": "Acme"},
+                "categoryPath": "Home > Kitchen > Coffee",
+            }
+        ]
+    }
+
+    def fake_urlopen(request, timeout=0):
+        assert request.full_url.startswith(ebay.SEARCH_URL)
+        assert "q=coffee" in request.full_url
+        assert "limit=5" in request.full_url
+        headers = {key.lower(): value for key, value in request.header_items()}
+        assert headers["authorization"] == "Bearer token"
+        assert headers["x-ebay-c-marketplace-id"] == "EBAY_GB"
+        return DummyResponse(payload)
+
+    monkeypatch.setattr(ebay, "urlopen", fake_urlopen)
+
+    results = ebay.search("coffee", limit=5, token="token", marketplace_id="EBAY_GB")
+    assert len(results) == 1
+    item = results[0]
+    assert item["id"] == "123"
+    assert item["price"] == pytest.approx(19.99)
+    assert item["price_text"] == "$19.99"
+    assert item["category"] == "Coffee"
+    assert item["brand"] == "Acme"
+
+
+def test_get_token_without_credentials(monkeypatch):
+    monkeypatch.delenv("EBAY_CLIENT_ID", raising=False)
+    monkeypatch.delenv("EBAY_CLIENT_SECRET", raising=False)
+    assert ebay.get_token() is None


### PR DESCRIPTION
## Summary
- add an `ebay` CLI command to run Browse API lookups with either a table or JSON dump
- thread optional marketplace headers through the Python and Node eBay clients and document the new flag/env var
- cover the integration with dedicated unit tests for the CLI formatter and Browse client helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce145a42348333beb9eb9a19889871