### PR TITLE
Add products index page to generator

### DIFF
--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -14,6 +14,7 @@
           <li><a href="/how-we-curate/">How we curate</a></li>
           <li><a href="/contact/">Contact</a></li>
           <li><a href="/guides/">Guides</a></li>
+          <li><a href="/products/">Products</a></li>
           <li><a href="/surprise/">Spin up a surprise</a></li>
           <li><a href="/changelog/">Live changelog</a></li>
           <li><a href="/faq/">FAQ &amp; Disclosure</a></li>

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -27,6 +27,7 @@
         <a href="/categories/for-gamers/">Gamers</a>
         <a href="/categories/for-fandom/">Fandom</a>
         <a href="/categories/homebody-upgrades/">Homebody</a>
+        <a href="/products/">Products</a>
         <a href="/guides/">Guides</a>
         <a href="/about/">About</a>
         <a href="/how-we-curate/">How we curate</a>

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -27,7 +27,7 @@ def sample_products() -> list[Product]:
                     id=f"{category}-{index}",
                     title=f"{brand} {category} Item {index}",
                     url=url,
-                    image=None,
+                    image=f"https://img.example.com/{category.lower().replace(' ', '-')}-{index}.jpg",
                     price=price,
                     price_text=f"${price:,.2f}",
                     currency="USD",
@@ -57,7 +57,7 @@ def test_generator_outputs_required_files(tmp_path, monkeypatch):
 
     sitemap = (output_dir / "sitemap.xml").read_text(encoding="utf-8")
     assert sitemap.count("<url>") >= 19
-    for slug in ("/about/", "/how-we-curate/", "/contact/"):
+    for slug in ("/about/", "/how-we-curate/", "/contact/", "/products/"):
         assert f"<loc>https://example.com{slug}</loc>" in sitemap
     assert (output_dir / "rss.xml").exists()
     assert (output_dir / "robots.txt").exists()
@@ -73,6 +73,11 @@ def test_generator_outputs_required_files(tmp_path, monkeypatch):
     assert "hello@example.com" in contact_html
     curation_html = (output_dir / "how-we-curate" / "index.html").read_text(encoding="utf-8")
     assert "How we curate" in curation_html
+    products_index_html = (output_dir / "products" / "index.html").read_text(encoding="utf-8")
+    assert "feed-list" in products_index_html
+    sample_titles = [product.title for product in stored_products[:3]]
+    for title in sample_titles:
+        assert title in products_index_html
 
 
 def test_polish_guide_title_removes_for_a_and_right_now():


### PR DESCRIPTION
## Summary
- add a products index page generated from product preview cards and include it in the sitemap
- link the new catalog page from the site header and footer navigation
- extend generator tests to cover the products index output

## Testing
- pytest tests/test_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68ce1b6faedc833397c40331d83276cf