### PR TITLE
Add filters to product catalog

### DIFF
--- a/public/assets/products.js
+++ b/public/assets/products.js
@@ -1,0 +1,187 @@
+const catalogs = document.querySelectorAll('[data-product-catalog]');
+
+catalogs.forEach((catalog) => {
+  initCatalog(catalog);
+});
+
+function parseNumber(value) {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function readSelectedOption(select) {
+  if (!select) {
+    return null;
+  }
+  if (typeof select.selectedOptions !== 'undefined' && select.selectedOptions.length) {
+    return select.selectedOptions[0];
+  }
+  if (typeof select.selectedIndex === 'number' && select.selectedIndex >= 0) {
+    return select.options[select.selectedIndex] || null;
+  }
+  return null;
+}
+
+function initCatalog(catalog) {
+  const grid = catalog.querySelector('[data-product-grid]');
+  if (!grid) {
+    return;
+  }
+
+  const cards = Array.from(grid.querySelectorAll('[data-product-card]'));
+  if (!cards.length) {
+    return;
+  }
+
+  const form = catalog.querySelector('[data-product-form]');
+  const searchInput = catalog.querySelector('[data-product-search]');
+  const categorySelect = catalog.querySelector('[data-product-filter="category"]');
+  const priceSelect = catalog.querySelector('[data-product-filter="price"]');
+  const summary = catalog.querySelector('[data-product-summary]');
+  const emptyMessage = catalog.querySelector('[data-product-empty]');
+  const total = cards.length;
+  const totalLabel = total.toLocaleString();
+
+  const entries = cards.map((card) => {
+    let keywords = card.dataset.productKeywords || '';
+    if (!keywords) {
+      const fallback = [
+        card.dataset.productTitle,
+        card.dataset.productBrand,
+        card.dataset.productCategory,
+      ]
+        .filter(Boolean)
+        .join(' ');
+      keywords = fallback;
+    }
+    keywords = keywords.toLowerCase();
+
+    return {
+      card,
+      keywords,
+      category: (card.dataset.productCategory || '').toLowerCase(),
+      price: parseNumber(card.dataset.productPrice),
+    };
+  });
+
+  function readPriceSelection(select) {
+    if (!select || !select.value) {
+      return { min: null, max: null, missing: false };
+    }
+    const option = readSelectedOption(select);
+    if (!option) {
+      return { min: null, max: null, missing: false };
+    }
+    return {
+      min: parseNumber(option.dataset.productMin),
+      max: parseNumber(option.dataset.productMax),
+      missing: option.dataset.productMissing === 'true',
+    };
+  }
+
+  function applyFilters() {
+    const query = (searchInput?.value || '').trim().toLowerCase();
+    const category = (categorySelect?.value || '').trim().toLowerCase();
+    const priceSelection = readPriceSelection(priceSelect);
+    const hasPriceFilter =
+      priceSelection.missing || priceSelection.min !== null || priceSelection.max !== null;
+
+    let visibleCount = 0;
+
+    entries.forEach((entry) => {
+      let matches = true;
+
+      if (query && !entry.keywords.includes(query)) {
+        matches = false;
+      }
+
+      if (matches && category && entry.category !== category) {
+        matches = false;
+      }
+
+      if (matches) {
+        if (priceSelection.missing) {
+          if (entry.price !== null) {
+            matches = false;
+          }
+        } else if (priceSelection.min !== null || priceSelection.max !== null) {
+          if (entry.price === null) {
+            matches = false;
+          } else {
+            if (priceSelection.min !== null && entry.price < priceSelection.min) {
+              matches = false;
+            }
+            if (priceSelection.max !== null && entry.price >= priceSelection.max) {
+              matches = false;
+            }
+          }
+        }
+      }
+
+      entry.card.hidden = !matches;
+      if (matches) {
+        visibleCount += 1;
+      }
+    });
+
+    if (summary) {
+      summary.textContent = `Showing ${visibleCount.toLocaleString()} of ${totalLabel} products`;
+      summary.dataset.productCount = String(visibleCount);
+    }
+
+    if (emptyMessage) {
+      emptyMessage.hidden = visibleCount !== 0;
+    }
+
+    const hasActiveFilters = Boolean(query || category || hasPriceFilter);
+    if (hasActiveFilters) {
+      catalog.dataset.productActive = 'true';
+    } else {
+      delete catalog.dataset.productActive;
+    }
+
+    if (searchInput) {
+      searchInput.classList.toggle('has-value', Boolean(query));
+    }
+    if (categorySelect) {
+      categorySelect.classList.toggle('has-selection', Boolean(category));
+    }
+    if (priceSelect) {
+      priceSelect.classList.toggle('has-selection', hasPriceFilter);
+    }
+  }
+
+  const scheduleApply = () => {
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(() => {
+        applyFilters();
+      });
+    } else {
+      applyFilters();
+    }
+  };
+
+  if (form) {
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+    });
+    form.addEventListener('reset', () => {
+      scheduleApply();
+    });
+  }
+
+  if (searchInput) {
+    searchInput.addEventListener('input', scheduleApply);
+  }
+  if (categorySelect) {
+    categorySelect.addEventListener('change', applyFilters);
+  }
+  if (priceSelect) {
+    priceSelect.addEventListener('change', applyFilters);
+  }
+
+  applyFilters();
+}

--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -1105,6 +1105,137 @@ p {
   grid-column: 1 / -1;
 }
 
+.product-catalog {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.75rem, 5vw, 3rem);
+}
+
+.product-catalog__controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  border-radius: 24px;
+  border: 1px solid rgba(180, 140, 230, 0.16);
+  background: linear-gradient(145deg, rgba(16, 7, 34, 0.92) 0%, rgba(26, 12, 44, 0.82) 100%);
+  box-shadow: 0 22px 48px rgba(6, 0, 30, 0.42);
+}
+
+.product-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.product-filters__fields {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.product-filters__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.product-filters__group--search {
+  grid-column: 1 / -1;
+}
+
+.product-filters__label {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.product-filters__input,
+.product-filters__select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(200, 170, 240, 0.22);
+  background: rgba(12, 5, 28, 0.78);
+  color: var(--fg);
+  font: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.product-filters__input::placeholder {
+  color: rgba(201, 188, 222, 0.72);
+}
+
+.product-filters__input:focus-visible,
+.product-filters__select:focus-visible {
+  outline: 2px solid rgba(255, 143, 207, 0.55);
+  outline-offset: 3px;
+  border-color: rgba(255, 143, 207, 0.65);
+  box-shadow: 0 0 0 3px rgba(255, 143, 207, 0.18);
+}
+
+.product-filters__select {
+  appearance: none;
+  padding-right: 2.75rem;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23c9bcde' d='M1.41.59 6 5.17 10.59.59 12 2l-6 6-6-6z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 1rem center;
+  background-size: 0.75rem auto;
+}
+
+.product-filters__input.has-value,
+.product-filters__select.has-selection {
+  border-color: rgba(255, 61, 158, 0.55);
+  box-shadow: 0 0 0 2px rgba(255, 61, 158, 0.18);
+}
+
+.product-filters__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.product-filters__reset {
+  font-size: 0.95rem;
+}
+
+.product-filters__summary {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+[data-product-catalog][data-product-active='true'] .product-catalog__controls {
+  border-color: rgba(255, 61, 158, 0.35);
+  box-shadow: 0 24px 58px rgba(255, 61, 158, 0.2);
+}
+
+[data-product-catalog][data-product-active='true'] .product-filters__summary {
+  color: var(--fg);
+}
+
+.product-catalog__results {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.product-catalog__empty {
+  margin: 0;
+  padding: 1.75rem 1.5rem;
+  border-radius: 18px;
+  border: 1px dashed rgba(200, 170, 240, 0.35);
+  background: rgba(16, 7, 34, 0.72);
+  color: var(--muted);
+  text-align: center;
+}
+
+.product-catalog__empty[hidden] {
+  display: none;
+}
+
 .item-feed[data-feed-complete] .feed-load-more {
   display: none;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,5 +15,6 @@
   <script type="module" src="/assets/nav.js"></script>
   <script type="module" src="/assets/feed.js"></script>
   <script type="module" src="/assets/home.js"></script>
+  <script type="module" src="/assets/products.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add search, category, and price filtering UI to the products index and update product cards with filter metadata
- style the catalog filters and empty state to match the existing theme
- add a client-side filter controller and load it from the base template

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce246b24348333b1e90716c397ae2b