### PR TITLE
Enhance daily refresh flow and polish guide output

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -24,7 +24,7 @@ jobs:
           AMAZON_PAAPI_SECRET_KEY: ${{ secrets.AMAZON_PAAPI_SECRET_KEY }}
           AMAZON_ASSOCIATE_TAG: ${{ secrets.AMAZON_ASSOCIATE_TAG }}
       - name: Generate guides
-        run: python -m giftgrab.cli roundups --limit 15
+        run: python -m giftgrab.cli roundups --limit 15 --skip-update
         env:
           EBAY_CAMPAIGN_ID: ${{ secrets.EBAY_CAMPAIGN_ID }}
           AMAZON_ASSOCIATE_TAG: ${{ secrets.AMAZON_ASSOCIATE_TAG }}

--- a/giftgrab/cli.py
+++ b/giftgrab/cli.py
@@ -33,6 +33,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Number of guides to publish",
     )
     roundups_parser.add_argument(
+        "--skip-update",
+        action="store_true",
+        help="Skip refreshing products before generating guides",
+    )
+    roundups_parser.add_argument(
         "--output",
         type=Path,
         default=Path("public"),
@@ -113,6 +118,10 @@ def handle_roundups(args: argparse.Namespace) -> None:
     if args.limit < 15:
         raise SystemExit("--limit must be at least 15")
     repository = ProductRepository()
+    if not getattr(args, "skip_update", False):
+        pipeline = GiftPipeline(repository=repository)
+        LOGGER.info("Refreshing catalog before generating guides")
+        pipeline.run()
     guides = generate_guides(repository, limit=args.limit)
     generator = SiteGenerator(output_dir=args.output)
     products = repository.load_products()

--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -655,6 +655,42 @@ p {
   line-height: 1.65;
 }
 
+.guide-meta {
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  background: rgba(14, 6, 30, 0.78);
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  box-shadow: var(--shadow);
+}
+
+.guide-meta__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem 1.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.guide-meta__item {
+  display: grid;
+  gap: 0.4rem;
+  align-content: start;
+}
+
+.guide-meta__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.guide-meta__value {
+  font-size: 1.08rem;
+  font-weight: 600;
+  color: var(--fg);
+}
+
 .press-section {
   border: 1px solid var(--border);
   border-radius: 28px;


### PR DESCRIPTION
## Summary
- run the catalog refresh before generating roundups by default and provide a flag to skip it when chaining commands
- expand roundup copy to highlight price bands, brand coverage, and sourcing while rendering a new guide highlights block
- style the new guide metadata panel and update the scheduled workflow to avoid redundant catalog refreshes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cebbe900048333822c11daeb8e6c90