### PR TITLE
Enhance product pages with detailed content

### DIFF
--- a/public/assets/theme.css
+++ b/public/assets/theme.css
@@ -1005,6 +1005,63 @@ p {
   line-height: 1.7;
 }
 
+.product-card__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.1rem clamp(1.1rem, 3vw, 1.6rem);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(16, 7, 32, 0.55);
+}
+
+.product-card__section-title {
+  margin: 0;
+  font-size: clamp(1.05rem, 2.8vw, 1.35rem);
+  font-weight: 700;
+  color: #fff;
+}
+
+.product-card__feature-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.55rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.product-card__feature-list li {
+  margin: 0;
+  padding: 0;
+}
+
+.product-card__detail-list {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.product-card__detail-item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.product-card__detail-label {
+  font-weight: 700;
+  color: #fff;
+}
+
+.product-card__detail-value {
+  font-weight: 500;
+}
+
 .product-card__cta {
   align-self: flex-start;
   margin-top: 0.5rem;


### PR DESCRIPTION
## Summary
- capture structured feature bullets on each product as part of the ingest pipeline so descriptions can rely on real item data
- generate product detail pages with richer copy, key feature bullets, and at-a-glance metadata instead of generic filler text
- style the new product page sections to match the existing card layout

## Testing
- npm run check *(fails: data/items.json is not valid JSON in the current repository snapshot)*
- python -m compileall giftgrab

------
https://chatgpt.com/codex/tasks/task_e_68cecc6f18ec8333b17811dc14709229